### PR TITLE
Assume what `subtle` does

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar_verus.rs
@@ -12,7 +12,7 @@ verus! {
         #[verifier::external_body]
         pub struct ExChoice(Choice);
 
-        pub spec fn boolify(c: Choice) -> bool;
+        pub uninterp spec fn boolify(c: Choice) -> bool;
 
         pub assume_specification [Choice::from](u: u8) -> (c: Choice)
             ensures u == 0 ==> boolify(c) == false,


### PR DESCRIPTION
Not going to merge this because @sbursuc has a different solution on main

Verus doesn't understand what `Choice` is. This PR gives Verus a spec to assume for `Choice::from` and `conditional_select`. So a non-Verus user can see that the executable code is unchanged because it still uses the same imports from the `subtle` crate