### PR TITLE
Format

### DIFF
--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -23,12 +23,7 @@
 // Linting:
 //------------------------------------------------------------------------
 #![cfg_attr(allow_unused_unsafe, allow(unused_unsafe))]
-#![warn(
-    clippy::unwrap_used,
-    missing_docs,
-    rust_2018_idioms,
-    unused_lifetimes,
-)]
+#![warn(clippy::unwrap_used, missing_docs, rust_2018_idioms, unused_lifetimes)]
 
 //------------------------------------------------------------------------
 // External dependencies:


### PR DESCRIPTION
Putting this in a separate PR to make the diff easier to read. This reduces the number of failing tests by 1

The failing clippy tests can probably be silenced. The `no_std` failures suggest that we need a `no_std` mode for `vstd` or other Verus dependencies. I haven't checked if they have one