### PR TITLE
No-overflow proof of `pow2k`

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 use vstd::arithmetic::div_mod::*;
 use vstd::arithmetic::mul::*;
-use vstd::arithmetic::power::pow;
+use vstd::arithmetic::power::*;
 use vstd::arithmetic::power2::*;
 use vstd::bits::*;
 use vstd::calc_macro::*;


### PR DESCRIPTION
This PR:
- Manually copies a lemma macro from `vstd`, because it's not exported, and we need it for `u128`
- Adds loop termination proof and invariants for `pow2k` 
- Proves no-overflow for `pow2k`
- Propagates implied requirements to `square(2)`