### PR TITLE
Add links to Verus docs in CLAUDE.md

### DIFF
--- a/curve25519-dalek/CLAUDE.md
+++ b/curve25519-dalek/CLAUDE.md
@@ -7,6 +7,13 @@ To test compilation with the fiat backend:
 RUSTFLAGS='--cfg curve25519_dalek_backend="fiat"' cargo check
 ```
 
+## Verus docs
+See https://verus-lang.github.io/verus/guide/ for tutorial
+
+See https://verus-lang.github.io/verus/verusdoc/vstd for vstd lemmas, 
+especially https://verus-lang.github.io/verus/verusdoc/vstd/arithmetic/index.html 
+for mul and div_mod lemmas
+
 ## Verus Verification
 
 Run Verus verification from the `curve25519-dalek` directory:


### PR DESCRIPTION
I set up Claude so it can access these websites 

In practice Claude rarely chooses to look at the docs. It might be better to point Claude at the source code for the lemmas, or manually collect statements of all the lemmas and put those in the prompt?