### PR TITLE
` load8_at` spec

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
@@ -16,6 +16,7 @@ verus! {
 
 
 pub proof fn bit_or_is_plus(a: u64, b: u8, k: u64)
+    by (bit_vector)
     requires
         k + 8 <= 64,
         a < 1u64 << k
@@ -23,10 +24,6 @@ pub proof fn bit_or_is_plus(a: u64, b: u8, k: u64)
         a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64)),
         a + ((b as u64) << (k as u64)) <= u64::MAX
 {
-    assert(a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))) by (bit_vector)
-        requires
-            k + 8 <= 64,
-            a < 1u64 << k;
 }
 
 pub open spec fn load8_at_or_version_rec(input: &[u8], i: usize, k: nat) -> u64

--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
@@ -23,80 +23,10 @@ pub proof fn bit_or_is_plus(a: u64, b: u8, k: u64)
         a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64)),
         a + ((b as u64) << (k as u64)) <= u64::MAX
 {
-    assume(false);
-    // assert(a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))) by (bit_vector);
-}
-
-pub proof fn bit_or_is_plus_alt(a: u8, b: u8, k: nat)
-    requires
-        k + 16 <= 64
-    ensures
-        ((a as u64) << (k as u64)) | ((b as u64)) << (k + 8) as u64
-        ==
-        (pow2(k) * a + pow2(k + 8) * b)
-{
-    let a64 = a as u64;
-    let b64 = b as u64;
-    let k64 = k as u64;
-    let k_8_64 = (k + 8) as u64;
-
-    let a_shl = a64 << k64;
-    let b_shl = b64 << k_8_64;
-
-    assert( a_shl == pow2(k) * a ) by {
-        assert(a64 as nat == a);
-        u8_times_pow2_fits_u64(a, k);
-        lemma_u64_shl_is_mul(a64, k64);
-    }
-
-    assert( b_shl == pow2(k + 8) * b ) by {
-        assert(b64 as nat == b);
-        u8_times_pow2_fits_u64(b, k + 8);
-        lemma_u64_shl_is_mul(b64, k_8_64);
-    }
-
-    if (a == 0 || b == 0) {
-        bitwise_or_r_zero_is_id((pow2(k) * a) as u64);
-        bitwise_or_l_zero_is_id((pow2(k + 8) * b) as u64);
-
-        assume(false);
-    }
-    else {
-        assert(a_shl <= pow2(k + 8) - pow2(k) < pow2(k + 8)) by {
-            pow2_mul_u8(a, k);
-            // 2^k > 0
-            lemma_pow2_pos(k);
-        }
-        assert(pow2(k + 8) <= b_shl <= pow2(k + 16) - pow2(k + 8)) by {
-            mul_le(1, b as nat, pow2(k + 8), pow2(k + 8));
-            pow2_mul_u8(b, k + 8);
-        }
-
-        assert(a_shl + b_shl <= u64::MAX) by {
-            // 2^(k + 8) > 0
-            assert(a_shl + b_shl <= (pow2(k + 16) - pow2(k)));
-            assert(a_shl + b_shl <= (pow2(64) - pow2(0))) by {
-                if (k + 16 < 64){
-                    lemma_pow2_strictly_increases(k + 16, 64);
-                }
-                if (0 < k){
-                    lemma_pow2_strictly_increases(0, k);
-                }
-                lemma_pow2_pos(0);
-            }
-            assert(pow2(64) - pow2(0) == u64::MAX) by {
-                lemma2_to64();
-                lemma2_to64_rest();
-            }
-        }
-
-        let sum = (a_shl + b_shl) as u64;
-
-        assert(a_shl | b_shl == sum) by {
-            assume(false);
-        }
-
-    }
+    assert(a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))) by (bit_vector)
+        requires
+            k + 8 <= 64,
+            a < 1u64 << k;
 }
 
 pub open spec fn load8_at_or_version_rec(input: &[u8], i: usize, k: nat) -> u64

--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/load8_lemmas.rs
@@ -1,20 +1,31 @@
 #![allow(unused)]
+use vstd::arithmetic::mul::*;
 use vstd::arithmetic::power2::*;
+use vstd::bits::*;
+use vstd::calc;
 use vstd::prelude::*;
+
+use super::super::common_verus::bit_lemmas::*;
+use super::super::common_verus::mul_lemmas::*;
+use super::super::common_verus::pow_lemmas::*;
+use super::super::common_verus::shift_lemmas::*;
+
+use super::field_core::*;
 
 verus! {
 
 
-pub proof fn bit_or_is_plus(a: u64, b: u8, k: nat)
+pub proof fn bit_or_is_plus(a: u64, b: u8, k: u64)
     requires
-        k + 16 <= 64,
+        k + 8 <= 64,
         a < 1u64 << k
     ensures
-        a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))
+        a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64)),
+        a + ((b as u64) << (k as u64)) <= u64::MAX
 {
-    assert(a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))) by (bit_vector);
+    assume(false);
+    // assert(a | ((b as u64) << (k as u64)) == a + ((b as u64) << (k as u64))) by (bit_vector);
 }
-
 
 pub proof fn bit_or_is_plus_alt(a: u8, b: u8, k: nat)
     requires
@@ -100,6 +111,30 @@ pub open spec fn load8_at_or_version_rec(input: &[u8], i: usize, k: nat) -> u64
     }
 }
 
+pub proof fn rec_version_is_exec(input: &[u8], i: usize)
+    ensures
+        load8_at_or_version_rec(input, i, 7)
+        ==
+        (input[i as int] as u64)
+        | ((input[i + 1] as u64) << 8)
+        | ((input[i + 2] as u64) << 16)
+        | ((input[i + 3] as u64) << 24)
+        | ((input[i + 4] as u64) << 32)
+        | ((input[i + 5] as u64) << 40)
+        | ((input[i + 6] as u64) << 48)
+        | ((input[i + 7] as u64) << 56)
+{
+    assert(load8_at_or_version_rec(input, i, 0) == (input[i as int] as u64));
+
+    assert forall |j: nat| 1 <= j <= 7 implies
+        #[trigger] load8_at_or_version_rec(input, i, j) ==
+        load8_at_or_version_rec(input, i, (j - 1) as nat)
+        | ((input[i + j] as u64) << 8 * j)
+    by {
+        reveal_with_fuel(load8_at_or_version_rec, 1);
+    }
+}
+
 pub open spec fn load8_at_plus_version_rec(input: &[u8], i: usize, k: nat) -> u64
     decreases k
 {
@@ -129,58 +164,180 @@ pub proof fn load8_at_plus_version_rec_is_bounded(input: &[u8], i: usize, k: nat
     }
     else {
         // k > 0
+        // Let f(k) := load8_at_plus_version_rec(input, i, k)
+        // IH: f(k - 1) < pow2(8 * k)
         assert(load8_at_plus_version_rec(input, i, (k - 1) as nat) < pow2(8 * k)) by {
             load8_at_plus_version_rec_is_bounded(input, i, (k - 1) as nat);
         }
 
-        assert((input[i + k] as u64) * pow2(8 * k) <= u64::MAX) by {
-            assert(u64::MAX == pow2(64) - 1) by {
-                lemma2_to64_rest();
-            }
-            assert((input[i + k] as u64) * pow2(8 * k) < pow2(64)) by {
-                assert((input[i + k] as u64) * pow2(8 * k) < pow2(8) * pow2(8 * k)) by {
-                    lemma_mul_strict_inequality(
-                        input[i + k] as int,
-                        pow2(8) as int,
-                        pow2(8 * k) as int
-                    );
+        let c = (input[i + k] as u64);
+        assert(c < pow2(8));
+
+        // f(k) = f(k - 1) + c * pow2(8 * k)
+        assert(c << (8 * k) == c * pow2(8 * k)) by {
+            assert((input[i + k] as u64) * pow2(8 * k) <= u64::MAX) by {
+                assert(u64::MAX == pow2(64) - 1) by {
+                    lemma2_to64_rest();
                 }
-                if (k < 7) {
-                    lemma_pow2_strictly_increases(8 * k, 56);
+                assert(c * pow2(8 * k) < pow2(64)) by {
+                    assert(c * pow2(8 * k) < pow2(8) * pow2(8 * k)) by {
+                        lemma_mul_strict_inequality(
+                            c as int,
+                            pow2(8) as int,
+                            pow2(8 * k) as int
+                        );
+                    }
+                    assert(pow2(8) * pow2(8 * k) <= pow2(64)) by {
+                        assert(pow2(8 * k) <= pow2(56)) by {
+                            if (k < 7) {
+                                lemma_pow2_strictly_increases(8 * k, 56);
+                            }
+                        }
+                        lemma_pow2_pos(8);
+                        lemma_mul_inequality(
+                            pow2(8 * k) as int,
+                            pow2(56) as int,
+                            pow2(8) as int
+                        );
+                        lemma_pow2_adds(8, 56);
+                    }
                 }
-                lemma_pow2_adds(8, 56);
             }
+            lemma_u64_shl_is_mul(c, (8 * k) as u64);
         }
 
-        // lemma_pow2_pos(8);
-        //     lemma_mul_strict_inequality(
-        //         load8_at_plus_version_rec(input, i, (k -1) as nat) as nat,
-        //         pow2(8 * k),
-        //         pow2(8)
-        //     );
+        // f(k - 1) < 1 * 2^(8k)
+        // c <= 2^8 - 1
+        // f(k -1) + c * 2^8k < 2^8 * 2^8k = 2^(8 * (k + 1))
 
-        // lemma_pow2_adds(8 * k, 8);
+        assert(load8_at_plus_version_rec(input, i, k) < pow2(8 * k) + c * pow2(8 * k));
+
+        assert(pow2(8 * k) + c * pow2(8 * k) <= pow2(8 * (k +1))) by {
+            // x + c * x == c ( x + 1 )
+            assert( pow2(8 * k) + c * pow2(8 * k) == pow2(8 *k) * (c + 1) ) by {
+                lemma_mul_is_distributive_add( pow2(8 * k) as int, c as int, 1 );
+            }
+            assert(c + 1 <= pow2(8));
+
+            assert(pow2(8 * k) * (c + 1) <= pow2(8 * (k + 1))) by {
+                lemma_mul_inequality(
+                    (c + 1) as int,
+                    pow2(8) as int,
+                    pow2(8 * k) as int
+                );
+                lemma_pow2_adds(8, 8 * k);
+                lemma_mul_is_distributive_add(8, 1, k as int);
+            }
+        }
     }
 }
 
-// pub proof fn load8_at_versions_equivalent(input: &[u8], i: usize, k: nat)
-//     requires
-//         k <= 7
-//     ensures
-//         load8_at_or_version_rec(input, i, k) == load8_at_plus_version_rec(input, i, k)
-//     decreases k
-// {
-//     if (k == 0){
-//         // trivial
-//     }
-//     else {
-//         load8_at_versions_equivalent(input, i, (k - 1) as nat);
-//         let prev = load8_at_plus_version_rec(input, i, (k - 1) as nat);
-//         assert(prev < (1u64 << 8 * k));
-//         bit_or_is_plus(prev, input[i + k], 8 * k);
-//     }
-// }
+pub proof fn plus_version_is_spec(input: &[u8], i: usize)
+    ensures
+        load8_at_plus_version_rec(input, i, 7)
+        ==
+        load8_at_spec(input, i)
+{
+    assert(load8_at_plus_version_rec(input, i, 0) == input[i as int] as u64);
 
+    assert(
+        load8_at_plus_version_rec(input, i, 7)
+        ==
+         (input[i as int] as u64)
+        + ((input[i + 1] as u64) << 8)
+        + ((input[i + 2] as u64) << 16)
+        + ((input[i + 3] as u64) << 24)
+        + ((input[i + 4] as u64) << 32)
+        + ((input[i + 5] as u64) << 40)
+        + ((input[i + 6] as u64) << 48)
+        + ((input[i + 7] as u64) << 56)
+    ) by {
+        assert forall |j: nat| 1 <= j <= 7 implies
+        #[trigger] load8_at_plus_version_rec(input, i, j)
+        ==
+        load8_at_plus_version_rec(input, i, (j - 1) as nat) + ((input[i + j] as u64) << j * 8)
+        by {
+            reveal_with_fuel(load8_at_plus_version_rec, 1);
+
+            assert(pow2(8 * (j + 1)) - 1 <= pow2(64) - 1) by {
+                if (j < 7){
+                    lemma_pow2_strictly_increases(8 * (j + 1), 64);
+                }
+            }
+
+            assert(pow2(64) - 1 == u64::MAX) by {
+                lemma2_to64_rest();
+            }
+
+            assert(u8::MAX + 1 == pow2(8)) by {
+                lemma2_to64();
+            }
+
+            lemma_pow2_adds(8, j * 8);
+
+            assert(load8_at_plus_version_rec(input, i, (j - 1) as nat) + ((input[i + j] as u64) << j * 8) <= u64::MAX) by {
+                assert(load8_at_plus_version_rec(input, i, (j - 1) as nat) <= pow2(8 * j) - 1 ) by {
+                    load8_at_plus_version_rec_is_bounded(input, i, (j - 1) as nat);
+                }
+
+                assert((input[i + j] as u64) << j * 8 <= u8::MAX * pow2(j * 8) ) by {
+                    // input[k] < MAX8 => input[k] * 2^(8j) < MAX8 * 2^(8j)
+                    lemma_mul_inequality(input[i + j] as int, u8::MAX as int, pow2(j * 8) as int);
+                    assert((input[i + j] as u64) * pow2(j * 8) <= u64::MAX) by {
+                        assert(u8::MAX * pow2(j * 8) <= pow2(64) - 1) by {
+                            assert(
+                                u8::MAX * pow2(j * 8)
+                                ==
+                                (pow2(8) - 1) * pow2(j * 8)
+                                ==
+                                pow2(8 * (j + 1)) - pow2(j * 8)
+                            );
+                            assert(pow2(j * 8) > 1) by {
+                                lemma2_to64(); // pow2(0)
+                                lemma_pow2_strictly_increases(0, j * 8)
+                            }
+                        }
+                    }
+                    lemma_u64_shl_is_mul((input[i + j] as u64), (j * 8) as u64);
+
+                }
+
+                assert(
+                    load8_at_plus_version_rec(input, i, (j - 1) as nat) + ((input[i + j] as u64) << j * 8)
+                    <=
+                    pow2(8 * (j + 1)) - 1
+                ) by {
+                    lemma_mul_is_distributive_add(1, u8::MAX as int, pow2(j * 8) as int);
+                }
+            }
+
+        }
+    }
+
+    assume(false);
+
+}
+
+pub proof fn load8_at_versions_equivalent(input: &[u8], i: usize, k: nat)
+    requires
+        k <= 7
+    ensures
+        load8_at_or_version_rec(input, i, k) == load8_at_plus_version_rec(input, i, k)
+    decreases k
+{
+    if (k == 0){
+        // trivial
+    }
+    else {
+        load8_at_versions_equivalent(input, i, (k - 1) as nat);
+        let prev = load8_at_plus_version_rec(input, i, (k - 1) as nat);
+        assert(prev < (1u64 << 8 * k)) by {
+            load8_at_plus_version_rec_is_bounded(input, i, (k - 1) as nat);
+            shift_is_pow2(8 * k);
+        }
+        bit_or_is_plus(prev, input[i + k], (8 * k) as u64);
+    }
+}
 
 pub proof fn load8_at_spec_fits_u64(input: &[u8], i: usize)
     requires

--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/mod.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/mod.rs
@@ -16,4 +16,4 @@ pub mod pow2k_lemmas;
 pub mod reduce_lemmas;
 
 // WIP
-// pub mod load8_lemmas;
+pub mod load8_lemmas;

--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/mod.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/mod.rs
@@ -15,5 +15,4 @@ pub mod pow2k_lemmas;
 
 pub mod reduce_lemmas;
 
-// WIP
 pub mod load8_lemmas;

--- a/curve25519-dalek/src/backend/serial/u64/field_verus.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_verus.rs
@@ -16,6 +16,7 @@ use super::common_verus::shift_lemmas::*;
 
 use super::field_lemmas::as_nat_lemmas::*;
 use super::field_lemmas::field_core::*;
+use super::field_lemmas::load8_lemmas::*;
 use super::field_lemmas::negate_lemmas::*;
 use super::field_lemmas::pow2_51_lemmas::*;
 use super::field_lemmas::pow2k_lemmas::*;
@@ -47,7 +48,9 @@ const fn load8_at(input: &[u8], i: usize) -> (r: u64)
         r as nat == load8_at_spec(input, i)
 {
     proof {
-        assume(false);
+        rec_version_is_exec(input, i);
+        load8_at_versions_equivalent(input, i, 7);
+        plus_version_is_spec(input, i);
     }
         (input[i] as u64)
     | ((input[i + 1] as u64) << 8)


### PR DESCRIPTION
Adds lemmas that prove the `nat`-arithmetic formulation of `load8_at`.