### PR TITLE
Add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build*.txt
 *.s
 .aider*
 .verus-solver-log
+.verus-log


### PR DESCRIPTION
jujutsu tried to snapshot a bunch of non-ignored files in .verus-log. I think verus now stores the profile logs in .verus-log instead of .verus-solver-log?
