### PR TITLE
Stability fix

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/field_lemmas/limbs_to_bytes_lemmas.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field_lemmas/limbs_to_bytes_lemmas.rs
@@ -255,8 +255,8 @@ proof fn lemma_limb0_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     assert(pow2(8) == 256);
 
     // Stabilization placeholders
-    assert(pow2( 0) == pow2(0 * 8));
-    assert(pow2( 8) == pow2(1 * 8));
+    assert(pow2(0) == pow2(0 * 8));
+    assert(pow2(8) == pow2(1 * 8));
     assert(pow2(16) == pow2(2 * 8));
     assert(pow2(24) == pow2(3 * 8));
     assert(pow2(32) == pow2(4 * 8));
@@ -569,8 +569,8 @@ proof fn lemma_limb1_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     lemma_pow2_adds(48, 3);
 
     // Stabilization placeholders
-    assert(pow2( 0) == pow2(0 * 8));
-    assert(pow2( 8) == pow2(1 * 8));
+    assert(pow2(0) == pow2(0 * 8));
+    assert(pow2(8) == pow2(1 * 8));
     assert(pow2(16) == pow2(2 * 8));
     assert(pow2(24) == pow2(3 * 8));
     assert(pow2(32) == pow2(4 * 8));
@@ -960,8 +960,8 @@ proof fn lemma_limb2_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     assert(pow2(102) == pow2(96) * 64);
 
     // Stabilization placeholders
-    assert(pow2( 0) == pow2(0 * 8));
-    assert(pow2( 8) == pow2(1 * 8));
+    assert(pow2(0) == pow2(0 * 8));
+    assert(pow2(8) == pow2(1 * 8));
     assert(pow2(16) == pow2(2 * 8));
     assert(pow2(24) == pow2(3 * 8));
     assert(pow2(32) == pow2(4 * 8));
@@ -1337,8 +1337,8 @@ proof fn lemma_limb3_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     lemma_pow2_adds(152, 1);  // 2^153 = 2^152 * 2
 
     // Stabilization placeholders
-    assert(pow2( 0) == pow2(0 * 8));
-    assert(pow2( 8) == pow2(1 * 8));
+    assert(pow2(0) == pow2(0 * 8));
+    assert(pow2(8) == pow2(1 * 8));
     assert(pow2(16) == pow2(2 * 8));
     assert(pow2(24) == pow2(3 * 8));
     assert(pow2(32) == pow2(4 * 8));
@@ -1673,8 +1673,8 @@ proof fn lemma_limb4_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     lemma_pow2_adds(200, 4);  // 2^204 = 2^200 * 2^4
 
     // Stabilization placeholders
-    assert(pow2( 0) == pow2(0 * 8));
-    assert(pow2( 8) == pow2(1 * 8));
+    assert(pow2(0) == pow2(0 * 8));
+    assert(pow2(8) == pow2(1 * 8));
     assert(pow2(16) == pow2(2 * 8));
     assert(pow2(24) == pow2(3 * 8));
     assert(pow2(32) == pow2(4 * 8));


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
- [ ] [Verification status](https://github.com/Beneficial-AI-Foundation/dalek-lite/wiki/Verification-Status) updated

Discussion copied from Slack:

> ok, so the issue was, best as I can localize it, there was a lemma about f(pow2(k * 8)), and the solver knew e.g. f(pow2(2 * 8)) held, but may or may not have inferred that f(pow2(16)) held. Semantically, they're obviously the same, but I guess this depended on whether the solver instantiated the simplification 2 * 8 == 16 inside the nested expression

The minimal-change fix is to add explicit asserts `pow(k * 8) == pow2(eval(k * 8))` (e.g. `pow2(2 * 8) == pow2(16)`), but #190  should address these proofs more thoroughly.

closes #213 