### PR TITLE
Refactor scalar lemmas

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/scalar.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar.rs
@@ -21,6 +21,8 @@ use zeroize::Zeroize;
 use crate::constants;
 
 #[allow(unused_imports)]
+use crate::lemmas::core_lemmas::*;
+#[allow(unused_imports)]
 use crate::lemmas::scalar_byte_lemmas::scalar_to_bytes_lemmas::*;
 #[allow(unused_imports)]
 use crate::lemmas::scalar_lemmas::*;
@@ -239,8 +241,6 @@ impl Scalar52 {
         proof {
             // The main lemma proves the property using the non-recursive (_aux) versions
             lemma_as_bytes_52(self.limbs, s);
-            // Use equivalence lemmas to connect to the recursive versions in the ensures clause
-            lemma_bytes_to_nat_rec_equals_bytes_to_nat(&s);
             lemma_five_limbs_equals_to_nat(&self.limbs);
         }
 

--- a/curve25519-dalek/src/lemmas/common_lemmas/div_mod_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/common_lemmas/div_mod_lemmas.rs
@@ -128,4 +128,16 @@ pub proof fn lemma_u8_cast_is_mod_256(x: u64)
     assert((x as u8) == x % 256) by (bit_vector);
 }
 
+pub proof fn lemma_mul_both_sides_mod(x: int, y: int, z: int, m: int)
+    requires
+        m > 0,
+        x % m == y % m,
+    ensures
+        (x * z) % m == (y * z) % m,
+{
+    // Apply lemma_mul_mod_noop_right to both x and y
+    lemma_mul_mod_noop_right(z, x, m);
+    lemma_mul_mod_noop_right(z, y, m);
+}
+
 } // verus!

--- a/curve25519-dalek/src/lemmas/common_lemmas/pow_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/common_lemmas/pow_lemmas.rs
@@ -801,4 +801,67 @@ pub proof fn lemma_modular_bit_partitioning(a: nat, b: nat, k: nat, n: nat)
     }
 }
 
+// Proof that pow2(n) is even for n >= 1
+pub proof fn lemma_pow2_even(n: nat)
+    requires
+        n >= 1,
+    ensures
+        pow2(n) % 2 == 0,
+    decreases n,
+{
+    if n == 1 {
+        assert(pow2(1) == 2) by {
+            lemma2_to64();
+        };
+        assert(2int % 2int == 0) by { lemma_mod_self_0(2) };
+    } else {
+        let m = (n - 1) as nat;
+        lemma_pow2_adds(1, m);
+        assert(pow2(n) == pow2(1) * pow2(m));
+        assert(pow2(1) == 2) by { lemma2_to64() };
+
+        lemma_mul_mod_noop_right(2 as int, pow2(m) as int, 2 as int);
+
+        lemma_pow2_even(m);
+
+        assert((2 * (pow2(m) as int % 2)) % 2 == 0);
+        assert(pow2(n) as int % 2 == 0);
+    }
+}
+
+// If x ≡ 1 (mod m) then x^n ≡ 1 (mod m)
+pub proof fn lemma_pow_mod_one(x: int, n: nat, m: int)
+    requires
+        m > 1,
+        x % m == 1,
+    ensures
+        pow(x, n) % m == 1,
+    decreases n,
+{
+    if n == 0 {
+        assert(pow(x, 0) == 1) by { lemma_pow0(x) };
+        assert(1int % m == 1) by { lemma_small_mod(1nat, m as nat) };
+        assert(pow(x, n) % m == 1);
+    } else {
+        lemma_pow_mod_one(x, (n - 1) as nat, m);
+        // pow(x,n) == pow(x,n-1) * x
+        assert(pow(x, n) == pow(x, (n - 1) as nat) * x) by {
+            lemma_pow_adds(x, 1, (n - 1) as nat);
+            lemma_pow1(x);
+        };
+
+        // x^n = x^(n - 1) * x (mod m)
+        assert(pow(x, n) % m == (pow(x, (n - 1) as nat) * x) % m);
+        assert(pow(x, n) % m == ((pow(x, (n - 1) as nat) % m) * (x % m)) % m) by {
+            lemma_mul_mod_noop(pow(x, (n - 1) as nat), x, m);
+        };
+
+        assert(pow(x, n) % m == (1int * 1int) % m);
+        assert(pow(x, n) % m == 1int % m);
+        assert(1int % m == 1) by { lemma_small_mod(1nat, m as nat) };
+        assert(pow(x, n) % m == 1);
+
+    }
+}
+
 } // verus!

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -2597,9 +2597,6 @@ impl UnpackedScalar {
     {
         let bytes = self.as_bytes();
         proof {
-            // Bridge between recursive and non-recursive representations
-            // as_bytes() uses non-recursive versions, but pack() expects recursive versions
-            lemma_bytes_to_nat_rec_equals_bytes_to_nat(&bytes);
             lemma_five_limbs_equals_to_nat(&self.limbs);
         }
         let result = Scalar { bytes: bytes };


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**

closes #272 

Removes redundant lemmas, shortens some proofs, moves generic div-mod and pow lemmas to their appropriate category.