### PR TITLE
Add comment on _aux

### DIFF
--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -201,7 +201,7 @@ We use Rust's preferred snake-case style throughout.
 - Conversions should adopt the convention `[a]_as_[b]`, e.g. `u8_32_as_nat`
 - Lemmas should use the `lemma_` prefix (exceptions below), followed by the name of the function/category they describe, e.g. `lemma_load8_plus_fits_u64` or `lemma_pow2_sum_div_decomposition`
 - Proofs about top-level executable functions should use `proof_[fn]` and `no_overflow_[fn]` as their prefix instead, for functional correctness and overflow freedom respectively
-
+- If a spec function is used only as a helper in proofs but not in the specifications of any executable function, add the suffix `_aux`
 
 
 


### PR DESCRIPTION
I've been requesting this on PRs that introduce a spec function that is named almost the same as one of the existing spec functions and does almost the same thing, but is meant as a proof helper