### PR TITLE
Remove index_mut from tracked functions

### DIFF
--- a/functions_to_track.csv
+++ b/functions_to_track.csv
@@ -41,7 +41,6 @@ FieldElement51::pow2k,curve25519_dalek::backend::serial::u64::field
 FieldElement51::square,curve25519_dalek::backend::serial::u64::field
 FieldElement51::square2,curve25519_dalek::backend::serial::u64::field
 index,curve25519_dalek::backend::serial::u64::scalar
-index_mut,curve25519_dalek::backend::serial::u64::scalar
 m,curve25519_dalek::backend::serial::u64::scalar
 Scalar52::from_bytes,curve25519_dalek::backend::serial::u64::scalar
 Scalar52::from_bytes_wide,curve25519_dalek::backend::serial::u64::scalar


### PR DESCRIPTION
I faintly remember that we were going to stop tracking this one?

```rust
// VERIFICATION EXCLUDED: mutable returns unsupported by Verus
impl IndexMut<usize> for Scalar52 {
    fn index_mut(&mut self, _index: usize) -> &mut u64 {
        &mut (self.limbs[_index])
    }
}
```
Marking it as external body didn't work

AFAIK this function is used by libsignal though