### PR TITLE
Claude fix for verusfmt CI: exclude target/ directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         cargo install --path .
     - name: Run verusfmt check
       run: |
-        find . -name "*.rs" -type f | xargs verusfmt --check
+        find . -path ./target -prune -o -name "*.rs" -type f -print | xargs verusfmt --check
 
   check-libsignal:
     name: "`cargo check` on libsignal with this dalek-lite commit"


### PR DESCRIPTION
- Use -prune so only source files are checked by verusfmt.
- Made this PR because verusfmt is failing here for no other reason than target dir: 
https://github.com/Beneficial-AI-Foundation/dalek-lite/pull/290

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
