### PR TITLE
Remove 13 Debug::fmt and 10 (de)serialize functions from tracking

### DIFF
--- a/functions_to_track.csv
+++ b/functions_to_track.csv
@@ -30,8 +30,6 @@ Scalar::sub_assign(&Scalar),curve25519_dalek::scalar,SubAssign<&'b Scalar> for S
 Scalar::sub(&Scalar),curve25519_dalek::scalar,Sub<&'b Scalar> for Scalar
 Scalar::neg(self),curve25519_dalek::scalar,Neg for &Scalar
 Scalar::neg(self),curve25519_dalek::scalar,Neg for Scalar
-Scalar::serialize(S),curve25519_dalek::scalar,Serialize for Scalar
-Scalar::deserialize(D),curve25519_dalek::scalar,Deserialize<'de> for Scalar
 product(I),curve25519_dalek::scalar,
 Scalar::from(u8),curve25519_dalek::scalar,From<u8> for Scalar
 Scalar::from(u16),curve25519_dalek::scalar,From<u16> for Scalar
@@ -83,10 +81,6 @@ CompressedEdwardsY::to_bytes(&self),curve25519_dalek::edwards,CompressedEdwardsY
 CompressedEdwardsY::decompress(&self),curve25519_dalek::edwards,CompressedEdwardsY
 step_1(&CompressedEdwardsY),curve25519_dalek::edwards,
 "step_2(&CompressedEdwardsY, FieldElement, FieldElement, FieldElement)",curve25519_dalek::edwards,
-EdwardsPoint::serialize(S),curve25519_dalek::edwards,Serialize for EdwardsPoint
-EdwardsPoint::deserialize(D),curve25519_dalek::edwards,Deserialize<'de> for EdwardsPoint
-CompressedEdwardsY::serialize(S),curve25519_dalek::edwards,Serialize for CompressedEdwardsY
-CompressedEdwardsY::deserialize(D),curve25519_dalek::edwards,Deserialize<'de> for CompressedEdwardsY
 CompressedEdwardsY::identity(),curve25519_dalek::edwards,Identity for CompressedEdwardsY
 EdwardsPoint::identity(),curve25519_dalek::edwards,Identity for EdwardsPoint
 CompressedEdwardsY::zeroize(&self),curve25519_dalek::edwards,Zeroize for CompressedEdwardsY
@@ -128,10 +122,6 @@ CompressedRistretto::decompress(&self),curve25519_dalek::ristretto,CompressedRis
 step_1(&CompressedRistretto),curve25519_dalek::ristretto,
 step_2(FieldElement),curve25519_dalek::ristretto,
 CompressedRistretto::identity(),curve25519_dalek::ristretto,Identity for CompressedRistretto
-RistrettoPoint::serialize(S),curve25519_dalek::ristretto,Serialize for RistrettoPoint
-RistrettoPoint::deserialize(D),curve25519_dalek::ristretto,Deserialize<'de> for RistrettoPoint
-CompressedRistretto::serialize(S),curve25519_dalek::ristretto,Serialize for CompressedRistretto
-CompressedRistretto::deserialize(D),curve25519_dalek::ristretto,Deserialize<'de> for CompressedRistretto
 RistrettoPoint::compress(&self),curve25519_dalek::ristretto,RistrettoPoint
 RistrettoPoint::double_and_compress_batch(I),curve25519_dalek::ristretto,RistrettoPoint
 BatchCompressState::efgh(&self),curve25519_dalek::ristretto,BatchCompressState


### PR DESCRIPTION
If we agree to remove. 

These are deubg formatting functions. They simply pass the arguments to fmt, which is not supported by Verus. 

We can include them back at a later stage when we do a comprehensive analysis of libsignal deps. 

Removed: 

Scalar::fmt, CompressedEdwardsY::fmt, EdwardsPoint::fmt, CompressedRistretto::fmt, RistrettoPoint::fmt, Scalar52::fmt, FieldElement51::fmt, ProjectivePoint::fmt, CompletedPoint::fmt, AffineNielsPoint::fmt, ProjectiveNielsPoint::fmt,
NafLookupTable5::fmt, NafLookupTable8::fmt

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Source code modifications **highlighted and justified**
- [x] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
