### PR TITLE
Remove NafLookupTable fmt functions from tracking

### DIFF
--- a/functions_to_track.csv
+++ b/functions_to_track.csv
@@ -58,10 +58,8 @@ UnpackedScalar::invert(&self),curve25519_dalek::scalar,UnpackedScalar
 clamp_integer([u8; 32]),curve25519_dalek::scalar,
 NafLookupTable5<ProjectiveNielsPoint>::select(usize),curve25519_dalek::window,NafLookupTable5<ProjectiveNielsPoint>
 NafLookupTable5<AffineNielsPoint>::select(usize),curve25519_dalek::window,NafLookupTable5<AffineNielsPoint>
-NafLookupTable5::fmt(&core),curve25519_dalek::window,Debug for NafLookupTable5<T>
 NafLookupTable8<ProjectiveNielsPoint>::select(usize),curve25519_dalek::window,NafLookupTable8<ProjectiveNielsPoint>
 NafLookupTable8<AffineNielsPoint>::select(usize),curve25519_dalek::window,NafLookupTable8<AffineNielsPoint>
-NafLookupTable8::fmt(&core),curve25519_dalek::window,Debug for NafLookupTable8<T>
 NafLookupTable5::from(&EdwardsPoint),curve25519_dalek::window,From<&'a EdwardsPoint> for NafLookupTable5<ProjectiveNielsPoint>
 NafLookupTable5::from(&EdwardsPoint),curve25519_dalek::window,From<&'a EdwardsPoint> for NafLookupTable5<AffineNielsPoint>
 NafLookupTable8::from(&EdwardsPoint),curve25519_dalek::window,From<&'a EdwardsPoint> for NafLookupTable8<ProjectiveNielsPoint>


### PR DESCRIPTION
## Summary
Removes 2 Debug::fmt functions from tracking that were accidentally re-added.

## Details
These Debug::fmt functions were previously removed in PR #402 but were accidentally re-added by PR #401 (Window naf specs) which was based on an earlier commit before the fmt removal.

### Removed:
- `NafLookupTable5::fmt(&core)`
- `NafLookupTable8::fmt(&core)`

This aligns with the policy established in PR #402 that Debug::fmt trait implementations should not be tracked for verification progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)