### PR TITLE
Remove unused VartimePrecomputed* functions from tracking

### DIFF
--- a/functions_to_track.csv
+++ b/functions_to_track.csv
@@ -109,8 +109,6 @@ Scalar::mul(&EdwardsPoint),curve25519_dalek::edwards,Mul<&'b EdwardsPoint> for &
 EdwardsPoint::mul_base(&Scalar),curve25519_dalek::edwards,EdwardsPoint
 EdwardsPoint::mul_clamped([u8; 32]),curve25519_dalek::edwards,EdwardsPoint
 EdwardsPoint::mul_base_clamped([u8; 32]),curve25519_dalek::edwards,EdwardsPoint
-VartimeEdwardsPrecomputation::new(I),curve25519_dalek::edwards,VartimePrecomputedMultiscalarMul for VartimeEdwardsPrecomputation
-"VartimeEdwardsPrecomputation::optional_mixed_multiscalar_mul(I, J, K)",curve25519_dalek::edwards,VartimePrecomputedMultiscalarMul for VartimeEdwardsPrecomputation
 "EdwardsPoint::vartime_double_scalar_mul_basepoint(&Scalar, &EdwardsPoint, &Scalar)",curve25519_dalek::edwards,EdwardsPoint
 EdwardsPoint::mul_by_cofactor(&self),curve25519_dalek::edwards,EdwardsPoint
 EdwardsPoint::mul_by_pow_2(u32),curve25519_dalek::edwards,EdwardsPoint
@@ -146,8 +144,6 @@ RistrettoPoint::mul_assign(&Scalar),curve25519_dalek::ristretto,MulAssign<&'b Sc
 RistrettoPoint::mul(&Scalar),curve25519_dalek::ristretto,Mul<&'b Scalar> for &RistrettoPoint
 Scalar::mul(&RistrettoPoint),curve25519_dalek::ristretto,Mul<&'b RistrettoPoint> for &Scalar
 RistrettoPoint::mul_base(&Scalar),curve25519_dalek::ristretto,RistrettoPoint
-VartimeRistrettoPrecomputation::new(I),curve25519_dalek::ristretto,VartimePrecomputedMultiscalarMul for VartimeRistrettoPrecomputation
-"VartimeRistrettoPrecomputation::optional_mixed_multiscalar_mul(I, J, K)",curve25519_dalek::ristretto,VartimePrecomputedMultiscalarMul for VartimeRistrettoPrecomputation
 RistrettoBasepointTable::mul(&Scalar),curve25519_dalek::ristretto,Mul<&'b Scalar> for &RistrettoBasepointTable
 Scalar::mul(&RistrettoBasepointTable),curve25519_dalek::ristretto,Mul<&'a RistrettoBasepointTable> for &Scalar
 RistrettoBasepointTable::create(&RistrettoPoint),curve25519_dalek::ristretto,RistrettoBasepointTable
@@ -193,8 +189,6 @@ FieldElement51::pow2k(u32),curve25519_dalek::backend::serial::u64::field,FieldEl
 FieldElement51::square(&self),curve25519_dalek::backend::serial::u64::field,FieldElement51
 FieldElement51::square2(&self),curve25519_dalek::backend::serial::u64::field,FieldElement51
 "mul(&EdwardsPoint, &Scalar)",curve25519_dalek::backend::serial::scalar_mul::variable_base,
-VartimePrecomputedStraus::new(I),curve25519_dalek::backend::serial::scalar_mul::precomputed_straus,VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus
-"VartimePrecomputedStraus::optional_mixed_multiscalar_mul(I, J, K)",curve25519_dalek::backend::serial::scalar_mul::precomputed_straus,VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus
 "mul(&Scalar, &EdwardsPoint, &Scalar)",curve25519_dalek::backend::serial::scalar_mul::vartime_double_base,
 AffineNielsPoint::zeroize(&self),curve25519_dalek::backend::serial::curve_models,Zeroize for AffineNielsPoint
 ProjectiveNielsPoint::zeroize(&self),curve25519_dalek::backend::serial::curve_models,Zeroize for ProjectiveNielsPoint


### PR DESCRIPTION
After spending some time trying to specify these functions

- VartimePrecomputedStraus::new(I)
- VartimePrecomputedStraus::optional_mixed_multiscalar_mul(I, J, K)

I decided to check how they are instantiated by libsignal. 

It turns out that these and  4 other related functions are not used in the libsignal call chain, so we can remove them from current tracking. Please double check to confirm. 

**Removed functions:**
- VartimePrecomputedStraus::new(I)
- VartimePrecomputedStraus::optional_mixed_multiscalar_mul(I, J, K)
- VartimeEdwardsPrecomputation::new(I)
- VartimeEdwardsPrecomputation::optional_mixed_multiscalar_mul(I, J, K)
- VartimeRistrettoPrecomputation::new(I)
- VartimeRistrettoPrecomputation::optional_mixed_multiscalar_mul(I, J, K)

**Explanation**

These precomputation types are designed for scenarios where one repeatedly multiplies the same set of curve points by different scalars (precompute once, use many times). However, libsignal and the sister crates (ed25519-dalek, x25519-dalek) use the simpler one-shot multiscalar multiplication methods instead.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
