### PR TITLE
Add callgraph to GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,6 +32,7 @@ jobs:
   callgraph:
     name: Generate Call Graph
     continue-on-error: true  # Don't block deployment if callgraph generation fails
+    permissions: inherit  # Pass workflow permissions to the reusable workflow
     uses: Beneficial-AI-Foundation/scip-callgraph/.github/workflows/generate-callgraph.yml@main
     with:
       github_url: https://github.com/Beneficial-AI-Foundation/dalek-lite


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**

### Summary

Integrates the call graph visualization into the GitHub Pages site by restructuring the deployment workflow.

### Changes

Refactors `.github/workflows/deploy-pages.yml` from a single job into a 3-job pipeline:

1. **`callgraph`** - New job that invokes the reusable workflow from `scip-callgraph` to generate call graph visualization
   - Deploys to `/callgraph` subpath
   - Configured for the `curve25519-dalek` project

2. **`build-dashboard`** (renamed from `build-and-deploy`) - Builds the existing dashboard and uploads as an artifact

3. **`deploy`** - New job that:
   - Downloads both dashboard and callgraph artifacts
   - Fixes asset paths for subpath deployment (`/dalek-lite/callgraph/`)
   - Merges into a single site structure
   - Deploys combined site to GitHub Pages

### Benefits

- Call graph viewer now accessible at `/dalek-lite/callgraph/`
- Dashboard and callgraph build in parallel, improving CI efficiency
- Clean separation of concerns between build and deploy stages

---

_Generated by Claude Opus 4.5_