### PR TITLE
Remove tautological postcondition in step_1

### DIFF
--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -820,9 +820,7 @@ impl FieldElement {
             // NEW: The result is always the "non-negative" square root (LSB = 0)
             // This is a fundamental property of sqrt_ratio_i that the original code
             // relies on for decompression sign bit handling
-            (spec_field_element(&result.1) % p()) % 2 == 0,
-            // NEW: The result is bounded (reduced mod p)
-            spec_field_element(&result.1) < p(),
+            spec_field_element(&result.1) % 2 == 0,
             // Limb bounds: result is 52-bit bounded (from conditional_negate)
             fe51_limbs_bounded(
                 &result.1,

--- a/curve25519-dalek/src/lemmas/edwards_lemmas/decompress_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/edwards_lemmas/decompress_lemmas.rs
@@ -218,8 +218,10 @@ pub proof fn lemma_decompress_valid_branch(repr_bytes: &[u8; 32], x_orig: nat, p
         // step_1 postconditions
         spec_field_element(&point.Y) == spec_field_element_from_bytes(repr_bytes),
         math_on_edwards_curve(x_orig, spec_field_element(&point.Y)),
-        // X is non-negative root (LSB = 0) and bounded
-        (x_orig % p()) % 2 == 0,
+        // X is non-negative root (LSB = 0)
+        x_orig % 2 == 0,
+        // x_orig < p() is trivially true since x_orig = spec_field_element(&X)
+        // which is defined as spec_field_element_as_nat % p(). Required by internal lemma calls.
         x_orig < p(),
         // step_2 postconditions
         spec_field_element(&point.X) == (if (repr_bytes[31] >> 7) == 1 {
@@ -289,7 +291,10 @@ pub proof fn lemma_decompress_valid_branch(repr_bytes: &[u8; 32], x_orig: nat, p
             ;
 
             // Precondition 1: sqrt_ratio_i returns non-negative root (LSB = 0)
-            assert((x_before % p()) % 2 == 0);
+            // x_before % 2 == 0 from precondition, and x_before < p() so x_before % p() == x_before
+            assert((x_before % p()) % 2 == 0) by {
+                lemma_small_mod(x_before, p());
+            };
 
             // Precondition 2: sign_bit == 1 ==> x != 0
             assert(sign_bit == 1 ==> x_before % p() != 0) by {


### PR DESCRIPTION
PR https://github.com/Beneficial-AI-Foundation/dalek-lite/pull/576 wrongly introduced `spec_field_element(&X) < p()` as a postcondition for `step_1` and `sqrt_ratio_i`: `spec_field_element(&X)` is defined as:
```rust
pub open spec fn spec_field_element(fe: &FieldElement51) -> nat {
    spec_field_element_as_nat(fe) % p()
}
```

Similarly, `(spec_field_element(&X) % p()) % 2 == 0` contained a redundant `% p()`.

This PR changes:

- **`edwards.rs`**: Remove `spec_field_element(&X) < p()` from `step_1` postcondition
- **`field.rs`**: Remove same from `sqrt_ratio_i` postcondition  
- **Both files**: Simplify `(... % p()) % 2 == 0` → `... % 2 == 0`
- **`decompress_lemmas.rs`**: Update lemma preconditions to match; add explicit proof steps where `x < p()` is needed for internal lemma calls

Note that we cannot have `spec_field_element_as_nat < p()` as a postcondition because `sqrt_ratio_i` ensures only that `fe51_limbs_bounded(&result.1, 52)`.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
