### PR TITLE
`lemma_decompose` proof + proof repair from z3 bump

### DIFF
--- a/curve25519-dalek/src/backend/serial/u64/scalar.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar.rs
@@ -1226,11 +1226,12 @@ impl Scalar52 {
                 assert(limb_prod_bounded_u128(a.limbs, b.limbs, 5) && scalar52_to_nat(b)
                     < group_order() && spec_mul_internal(a, b) == spec_mul_internal(a, b));
             } else if scalar52_to_nat(a) < group_order() {
-                // Witness: bounded = b, canonical = a 
+                // Witness: bounded = b, canonical = a
                 assert(spec_mul_internal(b, a) == spec_mul_internal(a, b)) by {
-                    lemma_spec_mul_internal_commutative(a,b);
+                    lemma_spec_mul_internal_commutative(a, b);
                 }
-                assert(limb_prod_bounded_u128(b.limbs, a.limbs, 5) && scalar52_to_nat(a) < group_order());
+                assert(limb_prod_bounded_u128(b.limbs, a.limbs, 5) && scalar52_to_nat(a)
+                    < group_order());
             }
         }
         Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b))

--- a/curve25519-dalek/src/lemmas/field_lemmas/limbs_to_bytes_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/field_lemmas/limbs_to_bytes_lemmas.rs
@@ -1469,21 +1469,29 @@ proof fn lemma_limb3_contribution_correctness(limbs: [u64; 5], bytes: [u8; 32])
     // This gives us:
     assert(bytes[20] as nat * pow2(0) + bytes[21] as nat * pow2(8) + bytes[22] as nat * pow2(16)
         + bytes[23] as nat * pow2(24) + bytes[24] as nat * pow2(32) == middle_value) by {
-            lemma_5_bytes_reconstruct(middle_value, bytes[20], bytes[21], bytes[22], bytes[23], bytes[24]);
-        }
+        lemma_5_bytes_reconstruct(
+            middle_value,
+            bytes[20],
+            bytes[21],
+            bytes[22],
+            bytes[23],
+            bytes[24],
+        );
+    }
 
     // Now multiply both sides by 2^160 to get the bytes at their actual positions
-    assert(middle_value * pow2(160) == 
-        bytes[20] as nat * pow2(20 * 8) + bytes[21] as nat * pow2(21 * 8) + bytes[22] as nat
-        * pow2(22 * 8) + bytes[23] as nat * pow2(23 * 8) + bytes[24] as nat * pow2(24 * 8)
-    ) by {
+    assert(middle_value * pow2(160) == bytes[20] as nat * pow2(20 * 8) + bytes[21] as nat * pow2(
+        21 * 8,
+    ) + bytes[22] as nat * pow2(22 * 8) + bytes[23] as nat * pow2(23 * 8) + bytes[24] as nat * pow2(
+        24 * 8,
+    )) by {
         lemma_mul_distributive_5_terms(
             pow2(160) as int,
             (bytes[20] as nat * pow2(0)) as int,
             (bytes[21] as nat * pow2(8)) as int,
             (bytes[22] as nat * pow2(16)) as int,
             (bytes[23] as nat * pow2(24)) as int,
-            (bytes[24] as nat * pow2(32)) as int
+            (bytes[24] as nat * pow2(32)) as int,
         );
 
         // Distribute the multiplication into each term

--- a/curve25519-dalek/src/lemmas/scalar_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/scalar_lemmas.rs
@@ -38,18 +38,15 @@ verus! {
 
 pub proof fn lemma_spec_mul_internal_commutative(a: &Scalar52, b: &Scalar52)
     ensures
-        spec_mul_internal(a,b) == spec_mul_internal(b,a)
+        spec_mul_internal(a, b) == spec_mul_internal(b, a),
 {
     // spec_mul_internal contains sums of the form \sum_{i=0}^k a[i] * b[k-i]
-    // and 
-    // \sum_{i=0}^k a[i] * b[k-i] == 
+    // and
+    // \sum_{i=0}^k a[i] * b[k-i] ==
     // \sum_{i=0}^k b[k-i] * a[i] == {introduce j = k - i}
     // \sum_{j=0}^k b[j] * a[k-j]
-    assert forall |i: int,j: int| 0 <= i < 9 && 0 <= j < 9 implies 
-        ((a.limbs[i] as u128) * (b.limbs[j] as u128)) as u128 
-        ==
-        ((b.limbs[j] as u128) * (a.limbs[i] as u128)) as u128
-    by {
+    assert forall|i: int, j: int| 0 <= i < 9 && 0 <= j < 9 implies ((a.limbs[i] as u128) * (
+    b.limbs[j] as u128)) as u128 == ((b.limbs[j] as u128) * (a.limbs[i] as u128)) as u128 by {
         lemma_mul_is_commutative(a.limbs[i] as int, b.limbs[j] as int);
     }
 }
@@ -986,18 +983,22 @@ pub proof fn lemma_seq_u64_to_nat_subrange_extend(seq: Seq<u64>, i: int)
         // Show seq_u64_to_nat of a singleton is just that element
         assert(seq_u64_to_nat(seq.subrange(0, 1)) == seq[0] as nat) by {
             // definition
-            assert(seq_u64_to_nat(seq.subrange(0, 1)) == seq_to_nat_52(seq.subrange(0, 1).map(|i, x| x as nat)));
+            assert(seq_u64_to_nat(seq.subrange(0, 1)) == seq_to_nat_52(
+                seq.subrange(0, 1).map(|i, x| x as nat),
+            ));
             // subrange(0,1)
             assert(seq.subrange(0, 1).map(|i, x| x as nat) == seq![seq[0] as nat]);
             // definition, else branch
-            assert(seq_to_nat_52(seq![seq[0] as nat]) == seq[0] as nat + seq_to_nat_52(seq![seq[0] as nat].subrange(1, 1)) * pow2(52));
+            assert(seq_to_nat_52(seq![seq[0] as nat]) == seq[0] as nat + seq_to_nat_52(
+                seq![seq[0] as nat].subrange(1, 1),
+            ) * pow2(52));
             // subrange(1,1)
             assert(seq![seq[0] as nat].subrange(1, 1).len() == 0);
             // definition, if branch
             assert(seq_to_nat_52(seq![seq[0] as nat].subrange(1, 1)) == 0);
             // solver hint since pow2(52) is not evaluated!
             assert(0 * pow2(52) == 0) by {
-                lemma_mul_basics_1(pow2(52) as int); 
+                lemma_mul_basics_1(pow2(52) as int);
             };
         }
 
@@ -1239,22 +1240,22 @@ pub proof fn lemma_decompose(a: u64, mask: u64)
 
     let r = a % (pow2(52) as u64);
     let q = a / (pow2(52) as u64);
-    
+
     assert(a >> 52 == q) by {
         lemma_u64_shr_is_div(a, 52);
     }
-    
+
     assert(mask == low_bits_mask(52)) by {
         assert(1u64 << 52 == pow2(52)) by {
             lemma_u64_shift_is_pow2(52);
         }
     }
-    
+
     assert(a & mask == r) by {
         lemma_u64_low_bits_mask_is_mod(a, 52);
     }
-    
-    assert( a == q * pow2(52) + r) by {
+
+    assert(a == q * pow2(52) + r) by {
         lemma_fundamental_div_mod(a as int, pow2(52) as int);
         lemma_mul_is_commutative(q as int, pow2(52) as int);
     }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**

This PR introduces partial proof repair for assertions that break when using the latest z3 version (4.15.4) with `-V no-solver-version-check` as well as removes the last `assume(false)` introduced in 88f7396. It addresses only failed assertions, but not `rlimit` issues still present in 2 proofs.

Since the CI runs on a different z3 version and without `no-solver-version-check` it is expected that CI should fail on this PR