### PR TITLE
Fix spec and proof detection

### DIFF
--- a/scripts/analyze_verus_specs_proofs.py
+++ b/scripts/analyze_verus_specs_proofs.py
@@ -296,8 +296,22 @@ def parse_function_in_file(
         found_opening_paren = False
 
         # Find the end of the function signature (including specs)
+        # Skip characters inside comments to avoid counting parens/braces in comments
+        # (e.g., "// values are in [2^254, 2^255)" has a ) that would break paren tracking)
         while pos < len(content):
             char = content[pos]
+
+            # Skip line comments (// ... \n)
+            if char == "/" and pos + 1 < len(content) and content[pos + 1] == "/":
+                newline = content.find("\n", pos)
+                pos = newline + 1 if newline != -1 else len(content)
+                continue
+
+            # Skip block comments (/* ... */)
+            if char == "/" and pos + 1 < len(content) and content[pos + 1] == "*":
+                end = content.find("*/", pos + 2)
+                pos = end + 2 if end != -1 else len(content)
+                continue
 
             if char == "(":
                 paren_depth += 1


### PR DESCRIPTION
## Summary

- Fix false negatives in `analyze_verus_specs_proofs.py` where functions with specs/proofs were incorrectly reported as unspecified/unproved
- Root cause: the brace/paren tracking parser counted parens and braces inside `//` line comments and `/* */` block comments
- Example: `// values are in [2^254, 2^255)` has a `)` that broke paren depth tracking

## Corrected numbers

| Metric | Before fix | After fix |
|---|---|---|
| Functions with specs | 222/223 | **223/223 (100%)** |
| Functions with proofs | 180/223 | **181/223 (81%)** |

## Affected function

| Function | Before | After |
|---|---|---|
| `MontgomeryPoint::mul_base_clamped` | spec=no, proof=no | spec=yes, proof=yes |

## Test plan

- [x] Verified the affected function is now correctly detected
- [x] Full analysis run: 223/223 specified, 181 proved
- [x] No regressions in other function detection