### PR TITLE
Prove EdwardsPoint ct_eq 

### DIFF
--- a/.codex/skills/verus-proof-helper/references/workflow.md
+++ b/.codex/skills/verus-proof-helper/references/workflow.md
@@ -75,6 +75,10 @@ Cleanup checklist:
 
 - Remove redundant assertions (delete one at a time; re-verify).
 - Prefer `assert(...)` over `assert(...) by { ... }` when the `by` block has no real lemma calls.
-- Move lemma calls into the `assert .. by { ... }` block they justify (one lemma per assertion when possible).
+- **Prefer `assert(fact) by { lemma_call; }` over floating `lemma_call;` + `assert(fact);`.**
+  Wrap every lemma call in the `assert...by` that states the fact it establishes. Multiple lemmas
+  may share one block when they collectively prove a single fact. Floating lemma calls are acceptable
+  when: (a) the lemma provides a biconditional/background fact used across many assertions,
+  (b) wrapping causes rlimit blowup, or (c) the postcondition is trivially obvious from the name.
 - Keep comments concise and explain *why*, not *what*.
 - Remove unused general lemmas after a specialized lemma fully replaces them (search usages before deleting).

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1254,10 +1254,6 @@ impl ConstantTimeEq for EdwardsPoint {
         let result = choice_and(x_eq, y_eq);
 
         proof {
-            // Bridge byte comparison to canonical nat comparison
-            lemma_ct_eq_iff_canonical_nat(&xz, &xz_prime);
-            lemma_ct_eq_iff_canonical_nat(&yz, &yz_prime);
-
             let x1 = fe51_as_canonical_nat(&self.X);
             let y1 = fe51_as_canonical_nat(&self.Y);
             let z1 = fe51_as_canonical_nat(&self.Z);
@@ -1265,14 +1261,30 @@ impl ConstantTimeEq for EdwardsPoint {
             let y2 = fe51_as_canonical_nat(&other.Y);
             let z2 = fe51_as_canonical_nat(&other.Z);
 
+            // Bridge byte comparison to canonical nat comparison
+            assert((fe51_as_canonical_nat(&xz) == fe51_as_canonical_nat(&xz_prime)) <==> (
+            spec_fe51_as_bytes(&xz) == spec_fe51_as_bytes(&xz_prime))) by {
+                lemma_ct_eq_iff_canonical_nat(&xz, &xz_prime);
+            }
+            assert((fe51_as_canonical_nat(&yz) == fe51_as_canonical_nat(&yz_prime)) <==> (
+            spec_fe51_as_bytes(&yz) == spec_fe51_as_bytes(&yz_prime))) by {
+                lemma_ct_eq_iff_canonical_nat(&yz, &yz_prime);
+            }
+
             // Z-coordinates are nonzero (from math_is_valid_extended_edwards_point in type invariant)
             assert(z1 % p() != 0);
             assert(z2 % p() != 0);
 
             // Cross-multiplication iff affine division equality:
             // x1*z2 == x2*z1 ⟺ x1/z1 == x2/z2, similarly for y
-            lemma_cross_mul_iff_div_eq(x1, z1, x2, z2);
-            lemma_cross_mul_iff_div_eq(y1, z1, y2, z2);
+            assert((field_mul(x1, z2) == field_mul(x2, z1)) <==> (field_mul(x1, field_inv(z1))
+                == field_mul(x2, field_inv(z2)))) by {
+                lemma_cross_mul_iff_div_eq(x1, z1, x2, z2);
+            }
+            assert((field_mul(y1, z2) == field_mul(y2, z1)) <==> (field_mul(y1, field_inv(z1))
+                == field_mul(y2, field_inv(z2)))) by {
+                lemma_cross_mul_iff_div_eq(y1, z1, y2, z2);
+            }
         }
 
         result

--- a/curve25519-dalek/src/lemmas/field_lemmas/field_algebra_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/field_lemmas/field_algebra_lemmas.rs
@@ -2988,72 +2988,51 @@ pub proof fn lemma_cross_mul_iff_div_eq(a: nat, b: nat, c: nat, d: nat)
     let inv_b = field_inv(b);
     let inv_d = field_inv(d);
     let bd = field_mul(b, d);
-    let db = field_mul(d, b);
 
     p_gt_2();
 
-    lemma_field_mul_comm(b, d);
-    assert(bd == db);
+    assert(bd == field_mul(d, b)) by {
+        lemma_field_mul_comm(b, d);
+    }
 
     // Forward: a*d == c*b → a*inv(b) == c*inv(d)
     if field_mul(a, d) == field_mul(c, b) {
-        lemma_cancel_common_factor(a, b, d);
-        assert(field_mul(field_mul(a, d), field_inv(bd)) == field_mul(a, inv_b));
-
-        lemma_cancel_common_factor(c, d, b);
-        assert(field_mul(field_mul(c, b), field_inv(db)) == field_mul(c, inv_d));
-
-        // a*d == c*b, so (a*d)*inv(bd) == (c*b)*inv(bd) == (c*b)*inv(db) == c*inv(d)
-        assert(field_mul(field_mul(a, d), field_inv(bd)) == field_mul(
-            field_mul(c, b),
-            field_inv(bd),
-        ));
+        assert(field_mul(field_mul(a, d), field_inv(bd)) == field_mul(a, inv_b)) by {
+            lemma_cancel_common_factor(a, b, d);
+        }
+        assert(field_mul(field_mul(c, b), field_inv(bd)) == field_mul(c, inv_d)) by {
+            lemma_cancel_common_factor(c, d, b);
+            lemma_field_mul_comm(b, d);
+        }
+        // a*d == c*b ⇒ (a*d)*inv(bd) == (c*b)*inv(bd), chain the two equalities above
         assert(field_mul(a, inv_b) == field_mul(c, inv_d));
     }
     // Backward: a*inv(b) == c*inv(d) → a*d == c*b
 
     if field_mul(a, inv_b) == field_mul(c, inv_d) {
-        // (a*d)*(inv_b*b) == (a*inv_b)*(d*b)
-        lemma_four_factor_rearrange(a, d, inv_b, b);
-        lemma_inv_mul_cancel(b);
-        assert(field_mul(inv_b, b) == 1nat);
-        lemma_field_mul_one_right(field_mul(a, d));
-        assert(field_mul(field_mul(a, d), 1nat) == field_mul(a, d) % p());
+        assert(field_mul(inv_b, b) == 1nat) by {
+            lemma_inv_mul_cancel(b);
+        }
+        assert(field_mul(inv_d, d) == 1nat) by {
+            lemma_inv_mul_cancel(d);
+        }
 
-        // field_mul(a, d) < p() so mod is identity
-        assert(field_mul(a, d) < p()) by {
+        // (a*d)*(inv_b*b) == (a*inv_b)*(d*b), substitute inv_b*b = 1
+        assert(field_mul(a, d) == field_mul(field_mul(a, inv_b), field_mul(d, b))) by {
+            lemma_four_factor_rearrange(a, d, inv_b, b);
+            lemma_field_mul_one_right(field_mul(a, d));
+            lemma_small_mod(field_mul(a, d), p());
             lemma_mod_bound((a * d) as int, p() as int);
         }
-        assert(field_mul(a, d) % p() == field_mul(a, d)) by {
-            lemma_small_mod(field_mul(a, d), p());
-        }
-
-        // So: field_mul(a, d) == field_mul(field_mul(a, inv_b), field_mul(d, b))
-        assert(field_mul(a, d) == field_mul(field_mul(a, inv_b), field_mul(d, b)));
-
-        // Similarly for c*b
-        lemma_four_factor_rearrange(c, b, inv_d, d);
-        lemma_inv_mul_cancel(d);
-        assert(field_mul(inv_d, d) == 1nat);
-        lemma_field_mul_one_right(field_mul(c, b));
-
-        assert(field_mul(c, b) < p()) by {
+        // (c*b)*(inv_d*d) == (c*inv_d)*(b*d), substitute inv_d*d = 1
+        assert(field_mul(c, b) == field_mul(field_mul(c, inv_d), field_mul(b, d))) by {
+            lemma_four_factor_rearrange(c, b, inv_d, d);
+            lemma_field_mul_one_right(field_mul(c, b));
+            lemma_small_mod(field_mul(c, b), p());
             lemma_mod_bound((c * b) as int, p() as int);
         }
-        assert(field_mul(c, b) % p() == field_mul(c, b)) by {
-            lemma_small_mod(field_mul(c, b), p());
-        }
-
-        // So: field_mul(c, b) == field_mul(field_mul(c, inv_d), field_mul(b, d))
-        assert(field_mul(c, b) == field_mul(field_mul(c, inv_d), field_mul(b, d)));
-
-        // Given a*inv_b == c*inv_d, and d*b == b*d:
-        // field_mul(a, d) = (a*inv_b)*(d*b) = (c*inv_d)*(d*b) = (c*inv_d)*(b*d) = c*b
+        // a*inv_b == c*inv_d and d*b == b*d ⇒ chain gives a*d == c*b
         assert(field_mul(d, b) == field_mul(b, d));
-        assert(field_mul(field_mul(a, inv_b), field_mul(d, b)) == field_mul(
-            field_mul(c, inv_d),
-            field_mul(d, b),
-        ));
         assert(field_mul(a, d) == field_mul(c, b));
     }
 }


### PR DESCRIPTION
Replace the assume in ConstantTimeEq::ct_eq for EdwardsPoint with a complete proof that cross-multiplication equality (X*Z' == X'*Z) is equivalent to affine coordinate equality (X/Z == X'/Z'). Add lemma_cross_mul_iff_div_eq to field_algebra_lemmas proving the general field identity a*d == c*b iff a/b == c/d.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
