### PR TITLE
Scope lemma calls in assert-by blocks to fix rlimit

### DIFF
--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1107,9 +1107,15 @@ impl RistrettoPoint {
             use_type_invariant(t2);
             use_type_invariant(t4);
             use_type_invariant(t6);
-            lemma_unfold_edwards(t2);
-            lemma_unfold_edwards(t4);
-            lemma_unfold_edwards(t6);
+            assert(is_well_formed_edwards_point(t2)) by {
+                lemma_unfold_edwards(t2);
+            }
+            assert(is_well_formed_edwards_point(t4)) by {
+                lemma_unfold_edwards(t4);
+            }
+            assert(is_well_formed_edwards_point(t6)) by {
+                lemma_unfold_edwards(t6);
+            }
         }
         let p0 = self.0;  /* ORIGINAL CODE: self.0 */
         let p1 = &self.0 + &t2;  /* ORIGINAL CODE: &self.0 + &constants::EIGHT_TORSION[2] */


### PR DESCRIPTION
## Summary
- **straus.rs**: Scope `axiom_edwards_add_associative`, `lemma_neg_of_signed_scalar_mul`, `lemma_column_sum_canonical`, and `lemma_column_sum_step_zero_digit` in the VT inner while loop inside `assert(...) by {}` blocks to reduce Z3 solver pressure
- **ristretto.rs**: Scope `lemma_unfold_edwards` calls in `coset4` inside `assert(...) by {}` blocks to prevent non-deterministic rlimit failures

## Test plan
- [ ] `cargo verus verify -p curve25519-dalek` passes (1731 verified, 0 errors)
- [ ] `cargo test -p curve25519-dalek` passes (21 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)