### PR TITLE
verify LookupTable<ProjectiveNielsPoint>::select

### DIFF
--- a/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
@@ -861,7 +861,7 @@ impl Straus {
                     0 <= k < points_vec@.len() ==> is_well_formed_edwards_point(
                         #[trigger] points_vec@[k],
                     ),
-                // Each table is valid and has bounded limbs
+                // Each table is valid, has bounded limbs, and entries are valid
                 forall|k: int|
                     0 <= k < idx ==> {
                         &&& is_valid_lookup_table_projective(
@@ -870,6 +870,10 @@ impl Straus {
                             8,
                         )
                         &&& lookup_table_projective_limbs_bounded(lookup_tables@[k].0)
+                        &&& forall|j: int|
+                            0 <= j < 8 ==> is_valid_projective_niels_point(
+                                #[trigger] lookup_tables@[k].0[j],
+                            )
                     },
             decreases points_vec.len() - idx,
         {

--- a/curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs
@@ -164,6 +164,8 @@ pub(crate) fn mul(point: &EdwardsPoint, scalar: &Scalar) -> (result: EdwardsPoin
             fe51_limbs_bounded(&tmp1.T, 54),
             // Table validity (from LookupTable::from postcondition)
             is_valid_lookup_table_projective(lookup_table.0, *point, 8),
+            forall|k: int|
+                0 <= k < 8 ==> is_valid_projective_niels_point(#[trigger] lookup_table.0[k]),
             // Radix-16 reconstruction equality (from as_radix_16 postcondition)
             reconstruct_radix_16(scalar_digits@) == scalar_as_nat(scalar) as int,
             // Functional correctness: Horner partial evaluation

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1430,6 +1430,7 @@ impl EdwardsPoint {
             assert(projective_niels_corresponds_to_edwards(result, *self));
 
             // Validity: the existential witness is *self
+            assert(edwards_point_limbs_bounded(*self));
             assert(is_valid_projective_niels_point(result));
         }
 

--- a/curve25519-dalek/src/lemmas/edwards_lemmas/straus_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/edwards_lemmas/straus_lemmas.rs
@@ -436,8 +436,9 @@ pub open spec fn straus_ct_input_valid(
     &&& digits_seqs.len() as int == n_int
     &&& pts_affine.len() as int == n_int
     &&& n_int == spec_scalars.len()
-    &&& n_int == spec_points.len()
-    // Table validity + 54-bit limb bounds
+    &&& n_int
+        == spec_points.len()
+    // Table validity + 54-bit limb bounds + per-entry projective niels validity
     &&& forall|k: int|
         0 <= k < n_int ==> {
             &&& is_valid_lookup_table_projective(
@@ -446,6 +447,10 @@ pub open spec fn straus_ct_input_valid(
                 8,
             )
             &&& lookup_table_projective_limbs_bounded(lookup_tables_view[k].0)
+            &&& forall|j: int|
+                0 <= j < 8 ==> is_valid_projective_niels_point(
+                    #[trigger] lookup_tables_view[k].0[j],
+                )
         }
         // Radix-16 digit bounds (validity + reconstruction kept separate — see note above)
     &&& forall|k: int|

--- a/curve25519-dalek/src/specs/edwards_specs.rs
+++ b/curve25519-dalek/src/specs/edwards_specs.rs
@@ -615,16 +615,13 @@ pub open spec fn projective_niels_corresponds_to_edwards(
 }
 
 /// Check if a ProjectiveNielsPoint is valid
-/// A valid ProjectiveNielsPoint must correspond to some valid EdwardsPoint
+/// A valid ProjectiveNielsPoint must correspond to some valid, limb-bounded EdwardsPoint.
+/// The limb-bounded condition is needed because `choose` witnesses are spec-mode
+/// (no type invariant access), so limb bounds must be carried explicitly.
 pub open spec fn is_valid_projective_niels_point(niels: ProjectiveNielsPoint) -> bool {
-    // A ProjectiveNielsPoint is valid if there exists an EdwardsPoint that:
-    // 1. Is valid itself
-    // 2. The niels point corresponds to it
     exists|point: EdwardsPoint|
-        is_valid_edwards_point(point) && #[trigger] projective_niels_corresponds_to_edwards(
-            niels,
-            point,
-        )
+        is_valid_edwards_point(point) && edwards_point_limbs_bounded(point)
+            && #[trigger] projective_niels_corresponds_to_edwards(niels, point)
 }
 
 /// Extract affine coordinates (x, y) from a ProjectiveNielsPoint


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**

## Spec changes 

### 1. `is_valid_projective_niels_point` strengthened (`specs/edwards_specs.rs`)

The existential witness now requires `edwards_point_limbs_bounded(point)` in addition to `is_valid_edwards_point(point)`. This is necessary because `choose` witnesses in Verus spec mode have no access to type invariants, so limb bounds must be carried explicitly.

```rust
// Before:
exists|point: EdwardsPoint|
    is_valid_edwards_point(point)
        && #[trigger] projective_niels_corresponds_to_edwards(niels, point)

// After:
exists|point: EdwardsPoint|
    is_valid_edwards_point(point) && edwards_point_limbs_bounded(point)
        && #[trigger] projective_niels_corresponds_to_edwards(niels, point)
```

### 2. `LookupTable<ProjectiveNielsPoint>::select` -- new `requires` clause (`window.rs`)

Added per-entry validity precondition needed to propagate validity through `conditional_assign` and `conditional_negate`:

```rust
forall|j: int| 0 <= j < 8 ==> is_valid_projective_niels_point(#[trigger] self.0[j])
```

### 3. `LookupTable<ProjectiveNielsPoint>::from` -- new `ensures` clause (`window.rs`)

Establishes the precondition that `select` now requires. (Currently backed by an `assume` inside the `From` implementation, matching the existing pattern for the affine version.)

```rust
forall|j: int| 0 <= j < 8 ==> is_valid_projective_niels_point(#[trigger] result.0[j])
```

### 4. `straus_ct_input_valid` strengthened (`lemmas/edwards_lemmas/straus_lemmas.rs`)

Added to the inner `forall|k|` block to carry per-entry validity into the Straus algorithm loop invariants:

```rust
forall|j: int| 0 <= j < 8 ==>
    is_valid_projective_niels_point(#[trigger] lookup_tables_view[k].0[j])
```

### 5. `EdwardsPoint::as_projective_niels` -- proof assertion added (`edwards.rs`)

Added `assert(edwards_point_limbs_bounded(*self))` inside the proof block to satisfy the strengthened `is_valid_projective_niels_point` postcondition, which now requires the witness to be limb-bounded.

## New functions

### 6. `conditional_negate_projective_niels` (`backend/serial/u64/subtle_assumes.rs`)

New `#[verifier::external_body]` function providing precise `ensures` for `ProjectiveNielsPoint` negation: functional correctness (identity when choice is false, `negate_projective_niels` when true) and 54-bit limb bound preservation on all four fields (`Y_plus_X`, `Y_minus_X`, `Z`, `T2d`).

### 7. `lemma_identity_projective_niels_valid` (`lemmas/edwards_lemmas/curve_equation_lemmas.rs`)

Proves `is_valid_projective_niels_point(identity_projective_niels())` by constructing the identity `EdwardsPoint` as witness and verifying all correspondence conditions.

### 8. `lemma_negate_projective_niels_preserves_validity` (`lemmas/edwards_lemmas/curve_equation_lemmas.rs`)

Proves that negating a valid, 54-bit-bounded `ProjectiveNielsPoint` yields another valid `ProjectiveNielsPoint`, by constructing a negated `EdwardsPoint` witness and verifying curve membership and all Niels correspondence fields.

## Invariant propagation (no spec changes, but new invariant clauses)

### 9. `variable_base.rs` -- loop invariant strengthened

```rust
forall|k: int| 0 <= k < 8 ==>
    is_valid_projective_niels_point(#[trigger] lookup_table.0[k])
```

### 10. `straus.rs` -- lookup table construction loop invariant strengthened

Per-entry validity added to the `while` loop invariant, matching the new `straus_ct_input_valid` predicate.

closes #412 