### PR TITLE
verify RistrettoPoint::mul_base and from_uniform_bytes

### DIFF
--- a/curve25519-dalek/src/lemmas/ristretto_lemmas/axioms.rs
+++ b/curve25519-dalek/src/lemmas/ristretto_lemmas/axioms.rs
@@ -169,6 +169,31 @@ pub proof fn axiom_elligator_in_even_subgroup(r_0: nat)
     admit();
 }
 
+/// Axiom: The even subgroup (image of [2]) is closed under Edwards addition.
+///
+/// If P = 2·Q₁ and Q = 2·Q₂, then P + Q = 2·Q₁ + 2·Q₂ = 2·(Q₁ + Q₂).
+/// The algebraic identity follows from lemma_edwards_double_of_add (fully proven).
+/// Admitted because the existential witness requires lifting affine → EdwardsPoint.
+///
+/// Reference: standard group theory (sum of doubles is a double)
+pub proof fn axiom_even_subgroup_closed_under_add(p1: EdwardsPoint, p2: EdwardsPoint)
+    requires
+        is_in_even_subgroup(p1),
+        is_in_even_subgroup(p2),
+        is_well_formed_edwards_point(p1),
+        is_well_formed_edwards_point(p2),
+    ensures
+        forall|result: EdwardsPoint|
+            edwards_point_as_affine(result) == edwards_add(
+                edwards_point_as_affine(p1).0,
+                edwards_point_as_affine(p1).1,
+                edwards_point_as_affine(p2).0,
+                edwards_point_as_affine(p2).1,
+            ) && is_well_formed_edwards_point(result) ==> is_in_even_subgroup(result),
+{
+    admit();
+}
+
 // =============================================================================
 // Axiom: nat_invsqrt(−1 − d) = C_IAD  and  C_IAD² · (−1 − d) = 1
 // =============================================================================

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -2905,39 +2905,50 @@ impl RistrettoPoint {
         let result = R_1 + R_2;
         proof {
             // Add postcondition proves is_well_formed_edwards_point(result.0)
-            assume(is_in_even_subgroup(result.0));
-            assume(edwards_point_as_affine(result.0) == ristretto_from_uniform_bytes(bytes));
+            // Even subgroup: R_1 and R_2 are in the even subgroup (from elligator),
+            // and the even subgroup is closed under addition.
+            assert(is_in_even_subgroup(result.0)) by {
+                axiom_even_subgroup_closed_under_add(R_1.0, R_2.0);
+            };
+
+            // Functional correctness: connect exec operations to spec.
+            // The spec ristretto_from_uniform_bytes uses uniform_bytes_first/second (choose-based)
+            // and field_element_from_bytes. We bridge via view equality and from_bytes postconditions.
+            assert(edwards_point_as_affine(result.0) == ristretto_from_uniform_bytes(bytes)) by {
+                // Connect exec byte arrays to spec byte arrays via view equality
+                assert(r_1_bytes@ == bytes@.subrange(0, 32));
+                assert(r_2_bytes@ == bytes@.subrange(32, 64));
+            };
             assert(is_uniform_bytes(bytes) ==> is_uniform_ristretto_point(&result)) by {
-                // To prove A ==> B, assume A and derive B.
-                assume(is_uniform_bytes(bytes));
+                if is_uniform_bytes(bytes) {
+                    // 1. Split uniform bytes into independent uniform halves
+                    axiom_uniform_bytes_split(bytes, &r_1_bytes, &r_2_bytes);
+                    assert(is_uniform_bytes(&r_1_bytes));
+                    assert(is_uniform_bytes(&r_2_bytes));
+                    assert(is_independent_uniform_bytes32(&r_1_bytes, &r_2_bytes));
 
-                // 1. Split uniform bytes into independent uniform halves
-                axiom_uniform_bytes_split(bytes, &r_1_bytes, &r_2_bytes);
-                assert(is_uniform_bytes(&r_1_bytes));
-                assert(is_uniform_bytes(&r_2_bytes));
-                assert(is_independent_uniform_bytes32(&r_1_bytes, &r_2_bytes));
+                    // 2. from_bytes: uniform bytes -> uniform field elements (from from_bytes ensures)
+                    assert(is_uniform_field_element(&r_1));
+                    assert(is_uniform_field_element(&r_2));
 
-                // 2. from_bytes: uniform bytes -> uniform field elements (from from_bytes ensures)
-                assert(is_uniform_field_element(&r_1));
-                assert(is_uniform_field_element(&r_2));
+                    //    from_bytes_independent: independence is preserved
+                    axiom_from_bytes_independent(&r_1_bytes, &r_2_bytes, &r_1, &r_2);
+                    assert(is_independent_uniform_field_elements(&r_1, &r_2));
 
-                //    from_bytes_independent: independence is preserved
-                axiom_from_bytes_independent(&r_1_bytes, &r_2_bytes, &r_1, &r_2);
-                assert(is_independent_uniform_field_elements(&r_1, &r_2));
+                    // 3. Elligator: uniform field element -> uniform over Elligator IMAGE (~half group)
+                    axiom_uniform_elligator(&r_1, &R_1);
+                    axiom_uniform_elligator(&r_2, &R_2);
+                    assert(is_uniform_over_elligator_image(&R_1));
+                    assert(is_uniform_over_elligator_image(&R_2));
 
-                // 3. Elligator: uniform field element -> uniform over Elligator IMAGE (~half group)
-                axiom_uniform_elligator(&r_1, &R_1);
-                axiom_uniform_elligator(&r_2, &R_2);
-                assert(is_uniform_over_elligator_image(&R_1));
-                assert(is_uniform_over_elligator_image(&R_2));
+                    // 4. Elligator preserves independence
+                    axiom_uniform_elligator_independent(&r_1, &r_2, &R_1, &R_2);
+                    assert(is_independent_uniform_ristretto_points(&R_1, &R_2));
 
-                // 4. Elligator preserves independence
-                axiom_uniform_elligator_independent(&r_1, &r_2, &R_1, &R_2);
-                assert(is_independent_uniform_ristretto_points(&R_1, &R_2));
-
-                // 5. Two independent Elligator-image points sum to a full-uniform point
-                axiom_uniform_elligator_sum(&R_1, &R_2, &result);
-                assert(is_uniform_ristretto_point(&result));
+                    // 5. Two independent Elligator-image points sum to a full-uniform point
+                    axiom_uniform_elligator_sum(&R_1, &R_2, &result);
+                    assert(is_uniform_ristretto_point(&result));
+                }
             }
         }
         result
@@ -3495,16 +3506,6 @@ impl RistrettoPoint {
                 scalar * constants::RISTRETTO_BASEPOINT_TABLE
             }
         };
-        proof {
-            // The underlying Edwards mul_base ensures the functional correctness.
-            // Since edwards_scalar_mul == edwards_scalar_mul and
-            // spec_ristretto_basepoint() == spec_ristretto_basepoint(), the postcondition holds.
-            assume(is_well_formed_edwards_point(r.0));
-            assume(edwards_point_as_affine(r.0) == edwards_scalar_mul(
-                spec_ristretto_basepoint(),
-                scalar_as_nat(scalar),
-            ));
-        }
         r
     }
 }

--- a/docs/axiom_references.md
+++ b/docs/axiom_references.md
@@ -384,6 +384,18 @@ This document maps each axiom in the curve25519-dalek verification to its justif
 
 ---
 
+### axiom_even_subgroup_closed_under_add(p1, p2)
+**Signature:** `axiom_even_subgroup_closed_under_add(p1: EdwardsPoint, p2: EdwardsPoint)` — requires `is_in_even_subgroup(p1)`, `is_in_even_subgroup(p2)`, `is_well_formed_edwards_point(p1)`, `is_well_formed_edwards_point(p2)`; ensures that for any well-formed result with `edwards_point_as_affine(result) == edwards_add(affine(p1), affine(p2))`, `is_in_even_subgroup(result)`.
+
+**Claim:** The even subgroup 2E is closed under Edwards addition: if P = 2·Q₁ and Q = 2·Q₂, then P + Q = 2·(Q₁ + Q₂) ∈ 2E.
+
+**Reference:** Standard group theory; algebraic identity proven by `lemma_edwards_double_of_add` (fully verified)
+**URL:** N/A (standard algebra)
+
+**Justification:** The algebraic identity 2·A + 2·B = 2·(A + B) is proven by the fully-verified `lemma_edwards_double_of_add` in `curve_equation_lemmas.rs`. The `admit()` is needed only because the existential witness in `is_in_even_subgroup` requires an `EdwardsPoint` (projective representation), and lifting from affine coordinates to `EdwardsPoint` is not currently formalized.
+
+---
+
 ### axiom_ristretto_decode_on_curve(s)
 **Signature:** `axiom_ristretto_decode_on_curve(s: nat)` — requires `s < p()` and `spec_ristretto_decode_ok(s)`; ensures `is_on_edwards_curve(spec_ristretto_decode_x(s), spec_ristretto_decode_y(s))`.
 
@@ -544,6 +556,7 @@ This document maps each axiom in the curve25519-dalek verification to its justif
 | axiom_elligator_n_t_nonzero | ristretto_specs.rs | Paper + test | Hamburg 2015 §4; test (200+ inputs) |
 | axiom_elligator_t_completed_nonzero | ristretto_specs.rs | Paper + test | Hamburg 2015 §4; test (200+ inputs) |
 | axiom_elligator_in_even_subgroup | ristretto_specs.rs | Paper + test | Hamburg 2015/2019; test (200+ inputs) |
+| axiom_even_subgroup_closed_under_add | ristretto_lemmas/axioms.rs | Math (proven algebraically) | Group theory; lemma_edwards_double_of_add |
 | axiom_invsqrt_factors_over_square | field_specs.rs | Math + test | Standard finite field algebra; test (200 inputs) |
 | axiom_nat_invsqrt_neg_one_minus_d | ristretto_specs.rs | Computation + test | ristretto.group; test_nat_invsqrt_neg_one_minus_d |
 | axiom_ristretto_cross_mul_iff_equivalent | ristretto_specs.rs | Paper + test | Hamburg 2015 §4; Ristretto §3.2 |


### PR DESCRIPTION
### New axiom introduced

- `axiom_even_subgroup_closed_under_add(p1, p2)`

closes #443
closes #458 
