### PR TITLE
fix specs page for probe-verus schema 2.0 envelope

### DIFF
--- a/docs/specs.js
+++ b/docs/specs.js
@@ -72,7 +72,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Load data
     try {
         const response = await fetch("specs_data.json");
-        const data = await response.json();
+        let data = await response.json();
+        if (data.schema && data.data) {
+            data = data.data;
+        }
         verifiedFunctions = data.verified_functions || [];
         specFunctions = data.spec_functions || [];
     } catch (err) {


### PR DESCRIPTION
probe-verus 2.0 wraps specs-data output in an envelope with schema metadata, moving the payload under a .data field. Unwrap the envelope in specs.js so verified_functions and spec_functions are read correctly. Backward-compatible with the old bare format.

Made-with: Cursor

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
