### PR TITLE
verify vartime_double_base::mul (aA + bB)

### DIFF
--- a/curve25519-dalek/src/backend/serial/curve_models/mod.rs
+++ b/curve25519-dalek/src/backend/serial/curve_models/mod.rs
@@ -1766,6 +1766,11 @@ impl<'a, 'b> Sub<&'b AffineNielsPoint> for &'a EdwardsPoint {
                 let other_affine = affine_niels_point_as_affine_edwards(*other);
                 edwards_sub(self_affine.0, self_affine.1, other_affine.0, other_affine.1)
             },
+            // Limb bounds for result (from mul's 52-bit output → sub/add produce ≤54-bit)
+            fe51_limbs_bounded(&result.X, 54),
+            fe51_limbs_bounded(&result.Y, 54),
+            fe51_limbs_bounded(&result.Z, 54),
+            fe51_limbs_bounded(&result.T, 54),
     {
         proof {
             lemma_unfold_edwards(*self);

--- a/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -12,6 +12,8 @@
 
 use core::cmp::Ordering;
 
+#[cfg(feature = "precomputed-tables")]
+use crate::backend::serial::curve_models::AffineNielsPoint;
 use crate::backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
 use crate::constants;
 use crate::edwards::EdwardsPoint;
@@ -21,10 +23,22 @@ use crate::window::NafLookupTable5;
 
 #[cfg(verus_keep_ghost)]
 #[allow(unused_imports)]
+use crate::lemmas::edwards_lemmas::curve_equation_lemmas::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::lemmas::edwards_lemmas::straus_lemmas::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::lemmas::edwards_lemmas::vartime_double_base_lemmas::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
 use crate::specs::edwards_specs::*;
 #[cfg(verus_keep_ghost)]
 #[allow(unused_imports)]
 use crate::specs::field_specs::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::field_specs_u64::*;
 #[cfg(verus_keep_ghost)]
 #[allow(unused_imports)]
 use crate::specs::scalar_specs::*;
@@ -37,22 +51,15 @@ use vstd::prelude::*;
 
 verus! {
 
+#[verifier::rlimit(50)]
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
-// VERIFICATION NOTE: PROOF BYPASS - complex loop invariants not yet verified.
-// Uses `assume(false)` at loop entry points to skip internal verification.
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> (out: EdwardsPoint)
     requires
-// Input point must be well-formed
-
         is_well_formed_edwards_point(*A),
-        // Scalars must be canonical (< 2^255) for NAF computation
         scalar_as_nat(a) < pow2(255),
         scalar_as_nat(b) < pow2(255),
     ensures
-// Result is a well-formed Edwards point
-
         is_well_formed_edwards_point(out),
-        // Functional correctness: out = a*A + b*B where B is the Ed25519 basepoint
         edwards_point_as_affine(out) == {
             let aA = edwards_scalar_mul(edwards_point_as_affine(*A), scalar_as_nat(a));
             let bB = edwards_scalar_mul(spec_ed25519_basepoint(), scalar_as_nat(b));
@@ -66,33 +73,6 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> (out: EdwardsPoint)
     #[cfg(not(feature = "precomputed-tables"))]
     let b_naf = b.non_adjacent_form(5);
 
-    // Find starting index
-    let mut i: usize = 255;
-    /* <ORIGINAL CODE>
-    for j in (0..256).rev() {
-        i = j;
-        if a_naf[i] != 0 || b_naf[i] != 0 {
-            break;
-        }
-    }
-    </ORIGINAL CODE> */
-    // VERIFICATION NOTE: Verus doesn't support for-loops over Rev<Range<_>>
-    // This loop checks indices 255, 254, ..., 1, 0 (inclusive) to match original behavior.
-    loop
-        invariant
-            i <= 255,
-        decreases i + 1,  // +1 accounts for the final iteration at i == 0
-
-    {
-        if a_naf[i] != 0 || b_naf[i] != 0 {
-            break ;
-        }
-        if i == 0 {
-            break ;  // Checked index 0, now exit
-        }
-        i -= 1;
-    }
-
     let table_A = NafLookupTable5::<ProjectiveNielsPoint>::from(A);
     #[cfg(feature = "precomputed-tables")]
     let table_B = &constants::AFFINE_ODD_MULTIPLES_OF_BASEPOINT;
@@ -101,46 +81,552 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> (out: EdwardsPoint)
         &constants::ED25519_BASEPOINT_POINT,
     );
 
-    let mut r = ProjectivePoint::identity();
+    let ghost A_affine = edwards_point_as_affine(*A);
+    let ghost B_affine = spec_ed25519_basepoint();
+    let ghost pts_affine = seq![A_affine, B_affine];
+    let ghost nafs = seq![a_naf@, b_naf@];
+    let bp_for_proof = constants::ED25519_BASEPOINT_POINT;
 
-    loop
+    let mut r = ProjectivePoint::identity();
+    /* <ORIGINAL CODE>
+    // Find starting index
+    let mut i: usize = 255;
+    for j in (0..256).rev() {
+        i = j;
+        if a_naf[i] != 0 || b_naf[i] != 0 {
+            break;
+        }
+    }
+    // ... loop from i down to 0 using loop { ... if i == 0 { break; } i -= 1; } ...
+    </ORIGINAL CODE> */
+    // VERIFICATION NOTE: Restructured to while loop from 256 down to 1 (processing index i-1).
+    // Dropping the find-starting-index optimization doesn't affect correctness.
+    let mut i: usize = 256;
+
+    proof {
+        lemma_identity_projective_point_properties();
+        lemma_edwards_point_as_affine_canonical(*A);
+        lemma_edwards_point_as_affine_canonical(bp_for_proof);
+        assert(edwards_point_as_affine(bp_for_proof) == B_affine);
+        assert forall|j: int| 0 <= j < 8 implies is_valid_projective_niels_point(
+            #[trigger] table_A.0[j],
+        ) by {}
+        assert forall|j: int| 0 <= j < 8 implies projective_niels_point_as_affine_edwards(
+            #[trigger] table_A.0[j],
+        ) == edwards_scalar_mul(A_affine, (2 * j + 1) as nat) by {}
+        #[cfg(feature = "precomputed-tables")]
+        {
+            axiom_affine_odd_multiples_of_basepoint_valid();
+        }
+        #[cfg(not(feature = "precomputed-tables"))]
+        {
+            assert(naf_lookup_table5_projective_limbs_bounded(table_B.0));
+            assert forall|j: int| 0 <= j < 8 implies is_valid_projective_niels_point(
+                #[trigger] table_B.0[j],
+            ) by {}
+            assert forall|j: int| 0 <= j < 8 implies projective_niels_point_as_affine_edwards(
+                #[trigger] table_B.0[j],
+            ) == edwards_scalar_mul(B_affine, (2 * j + 1) as nat) by {}
+        }
+        assert(vt_double_base_input_valid(
+            a_naf@,
+            b_naf@,
+            table_A.0,
+            table_B.0,
+            A_affine,
+            B_affine,
+            pts_affine,
+            nafs,
+        ));
+        lemma_straus_vt_base(pts_affine, nafs);
+        assert(projective_point_as_affine_edwards(r) == edwards_identity());
+    }
+
+    while i > 0
         invariant
-            i <= 255,
+            0 <= i <= 256,
+            is_valid_projective_point(r),
+            fe51_limbs_bounded(&r.X, 52),
+            fe51_limbs_bounded(&r.Y, 52),
+            fe51_limbs_bounded(&r.Z, 52),
+            sum_of_limbs_bounded(&r.X, &r.Y, u64::MAX),
+            vt_double_base_input_valid(
+                a_naf@,
+                b_naf@,
+                table_A.0,
+                table_B.0,
+                A_affine,
+                B_affine,
+                pts_affine,
+                nafs,
+            ),
+            projective_point_as_affine_edwards(r) == straus_vt_partial(pts_affine, nafs, i as int),
         decreases i,
     {
-        assume(false);  // PROOF BYPASS
+        i = i - 1;
         let mut t = r.double();
+        let ghost doubled_affine = completed_point_as_affine_edwards(t);
+        let ghost col_a = straus_column_sum(pts_affine, nafs, i as int, 1);
 
-        match a_naf[i].cmp(&0) {
-            Ordering::Greater => t = &t.as_extended() + &table_A.select(a_naf[i] as usize),
-            Ordering::Less => t = &t.as_extended() - &table_A.select(-a_naf[i] as usize),
-            Ordering::Equal => {},
+        proof {
+            assert(p() > 2) by {
+                p_gt_2();
+            }
+            assert(edwards_add(
+                doubled_affine.0,
+                doubled_affine.1,
+                edwards_identity().0,
+                edwards_identity().1,
+            ) == doubled_affine) by {
+                lemma_edwards_add_identity_right_canonical(doubled_affine);
+            }
         }
 
+        // Process a_naf[i]
+        match a_naf[i].cmp(&0) {
+            Ordering::Greater => {
+                proof {
+                    let digit = a_naf@[i as int];
+                    assert(1 <= digit && digit <= 15 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(a_naf@, 5));
+                        assert(pow2(4) == 16) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_positive_select_preconditions(digit);
+                }
+                let selected_A = table_A.select(a_naf[i] as usize);
+                t = &t.as_extended() + &selected_A;
+                proof {
+                    let ghost digit = a_naf@[i as int];
+                    let term_a = edwards_scalar_mul_signed(A_affine, digit as int);
+                    assert(projective_niels_point_as_affine_edwards(selected_A) == term_a) by {
+                        lemma_naf_select_is_signed_scalar_mul_projective(
+                            table_A.0,
+                            digit,
+                            selected_A,
+                            A_affine,
+                            true,
+                        );
+                    }
+                    assert(col_a == term_a) by {
+                        lemma_vt_double_base_col_a(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                }
+            },
+            Ordering::Less => {
+                proof {
+                    let digit = a_naf@[i as int];
+                    assert(-15 <= digit && digit <= -1 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(a_naf@, 5));
+                        assert(pow2(4) == 16) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_negative_select_preconditions(digit);
+                }
+                let selected_A = table_A.select((-a_naf[i]) as usize);
+                t = &t.as_extended() - &selected_A;
+                proof {
+                    let ghost digit = a_naf@[i as int];
+                    let ghost abs_digit = (-digit) as i8;
+                    let term_a = edwards_scalar_mul_signed(A_affine, digit as int);
+                    assert(projective_niels_point_as_affine_edwards(selected_A)
+                        == edwards_scalar_mul_signed(A_affine, abs_digit as int)) by {
+                        lemma_naf_select_is_signed_scalar_mul_projective(
+                            table_A.0,
+                            abs_digit,
+                            selected_A,
+                            A_affine,
+                            true,
+                        );
+                    }
+                    assert(term_a == edwards_neg(
+                        projective_niels_point_as_affine_edwards(selected_A),
+                    )) by {
+                        lemma_neg_of_signed_scalar_mul(A_affine, abs_digit as int);
+                        assert(digit as int == -(abs_digit as int));
+                    }
+                    assert(col_a == term_a) by {
+                        lemma_vt_double_base_col_a(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                }
+            },
+            Ordering::Equal => {
+                proof {
+                    assert(col_a == edwards_identity()) by {
+                        lemma_column_sum_canonical(pts_affine, nafs, i as int, 0);
+                        lemma_column_sum_step_zero_digit(pts_affine, nafs, i as int, 0);
+                    }
+                }
+            },
+        }
+
+        let ghost col_ab = straus_column_sum(pts_affine, nafs, i as int, 2);
+
+        // Process b_naf[i] — precomputed-tables variant (AffineNielsPoint)
+        #[cfg(feature = "precomputed-tables")]
         match b_naf[i].cmp(&0) {
-            Ordering::Greater => t = &t.as_extended() + &table_B.select(b_naf[i] as usize),
-            Ordering::Less => t = &t.as_extended() - &table_B.select(-b_naf[i] as usize),
-            Ordering::Equal => {},
+            Ordering::Greater => {
+                proof {
+                    let digit = b_naf@[i as int];
+                    assert(1 <= digit && digit < 128 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(b_naf@, 8));
+                        assert(pow2(7) == 128) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_positive_select_preconditions_8(digit);
+                }
+                let b_digit = b_naf[i] as usize;
+                let selected_B = table_B.select(b_digit);
+                let ext_b = t.as_extended();
+                proof {
+                    let sel_idx = (b_digit as int) / 2;
+                    assert(is_valid_affine_niels_point(selected_B)) by {
+                        axiom_affine_odd_multiples_entries_valid(table_B.0, B_affine, sel_idx);
+                    }
+                    assert(edwards_z_sum_bounded(ext_b)) by {
+                        lemma_unfold_edwards(ext_b);
+                        crate::lemmas::field_lemmas::add_lemmas::lemma_sum_of_limbs_bounded_from_fe51_bounded(
+                        &ext_b.Z, &ext_b.Z, 52);
+                    }
+                }
+                t = &ext_b + &selected_B;
+                proof {
+                    let ghost digit = b_naf@[i as int];
+                    let term_b = edwards_scalar_mul_signed(B_affine, digit as int);
+                    assert(affine_niels_point_as_affine_edwards(selected_B) == term_b) by {
+                        lemma_naf_select_is_signed_scalar_mul_affine8(
+                            table_B.0,
+                            digit,
+                            selected_B,
+                            B_affine,
+                        );
+                    }
+                    assert(col_ab == edwards_add(col_a.0, col_a.1, term_b.0, term_b.1)) by {
+                        lemma_vt_double_base_col_ab(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    )) by {
+                        axiom_edwards_add_associative(
+                            doubled_affine.0,
+                            doubled_affine.1,
+                            col_a.0,
+                            col_a.1,
+                            term_b.0,
+                            term_b.1,
+                        );
+                    }
+                }
+            },
+            Ordering::Less => {
+                proof {
+                    let digit = b_naf@[i as int];
+                    assert(-128 < digit && digit <= -1 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(b_naf@, 8));
+                        assert(pow2(7) == 128) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_negative_select_preconditions_8(digit);
+                }
+                let abs_b_digit = (-b_naf[i]) as usize;
+                let selected_B = table_B.select(abs_b_digit);
+                let ext_b = t.as_extended();
+                proof {
+                    let sel_idx = (abs_b_digit as int) / 2;
+                    assert(is_valid_affine_niels_point(selected_B)) by {
+                        axiom_affine_odd_multiples_entries_valid(table_B.0, B_affine, sel_idx);
+                    }
+                    assert(edwards_z_sum_bounded(ext_b)) by {
+                        lemma_unfold_edwards(ext_b);
+                        crate::lemmas::field_lemmas::add_lemmas::lemma_sum_of_limbs_bounded_from_fe51_bounded(
+                        &ext_b.Z, &ext_b.Z, 52);
+                    }
+                }
+                t = &ext_b - &selected_B;
+                proof {
+                    let ghost digit = b_naf@[i as int];
+                    let ghost abs_digit = (-digit) as i8;
+                    let term_b = edwards_scalar_mul_signed(B_affine, digit as int);
+                    assert(affine_niels_point_as_affine_edwards(selected_B)
+                        == edwards_scalar_mul_signed(B_affine, abs_digit as int)) by {
+                        lemma_naf_select_is_signed_scalar_mul_affine8(
+                            table_B.0,
+                            abs_digit,
+                            selected_B,
+                            B_affine,
+                        );
+                    }
+                    assert(term_b == edwards_neg(affine_niels_point_as_affine_edwards(selected_B)))
+                        by {
+                        lemma_neg_of_signed_scalar_mul(B_affine, abs_digit as int);
+                        assert(digit as int == -(abs_digit as int));
+                    }
+                    assert(col_ab == edwards_add(col_a.0, col_a.1, term_b.0, term_b.1)) by {
+                        lemma_vt_double_base_col_ab(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    )) by {
+                        axiom_edwards_add_associative(
+                            doubled_affine.0,
+                            doubled_affine.1,
+                            col_a.0,
+                            col_a.1,
+                            term_b.0,
+                            term_b.1,
+                        );
+                    }
+                }
+            },
+            Ordering::Equal => {
+                proof {
+                    assert(col_ab == col_a) by {
+                        lemma_column_sum_canonical(pts_affine, nafs, i as int, 1);
+                        lemma_column_sum_step_zero_digit(pts_affine, nafs, i as int, 1);
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    ));
+                }
+            },
+        }
+
+        // Process b_naf[i] — non-precomputed variant (ProjectiveNielsPoint)
+        #[cfg(not(feature = "precomputed-tables"))]
+        match b_naf[i].cmp(&0) {
+            Ordering::Greater => {
+                proof {
+                    let digit = b_naf@[i as int];
+                    assert(1 <= digit && digit <= 15 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(b_naf@, 5));
+                        assert(pow2(4) == 16) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_positive_select_preconditions(digit);
+                }
+                let selected_B = table_B.select(b_naf[i] as usize);
+                t = &t.as_extended() + &selected_B;
+                proof {
+                    let ghost digit = b_naf@[i as int];
+                    let term_b = edwards_scalar_mul_signed(B_affine, digit as int);
+                    assert(projective_niels_point_as_affine_edwards(selected_B) == term_b) by {
+                        lemma_naf_select_is_signed_scalar_mul_projective(
+                            table_B.0,
+                            digit,
+                            selected_B,
+                            B_affine,
+                            true,
+                        );
+                    }
+                    assert(col_ab == edwards_add(col_a.0, col_a.1, term_b.0, term_b.1)) by {
+                        lemma_vt_double_base_col_ab(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    )) by {
+                        axiom_edwards_add_associative(
+                            doubled_affine.0,
+                            doubled_affine.1,
+                            col_a.0,
+                            col_a.1,
+                            term_b.0,
+                            term_b.1,
+                        );
+                    }
+                }
+            },
+            Ordering::Less => {
+                proof {
+                    let digit = b_naf@[i as int];
+                    assert(-15 <= digit && digit <= -1 && (digit as int) % 2 != 0) by {
+                        assert(is_valid_naf(b_naf@, 5));
+                        assert(pow2(4) == 16) by {
+                            lemma2_to64();
+                        }
+                    }
+                    lemma_naf_digit_negative_select_preconditions(digit);
+                }
+                let selected_B = table_B.select((-b_naf[i]) as usize);
+                t = &t.as_extended() - &selected_B;
+                proof {
+                    let ghost digit = b_naf@[i as int];
+                    let ghost abs_digit = (-digit) as i8;
+                    let term_b = edwards_scalar_mul_signed(B_affine, digit as int);
+                    assert(projective_niels_point_as_affine_edwards(selected_B)
+                        == edwards_scalar_mul_signed(B_affine, abs_digit as int)) by {
+                        lemma_naf_select_is_signed_scalar_mul_projective(
+                            table_B.0,
+                            abs_digit,
+                            selected_B,
+                            B_affine,
+                            true,
+                        );
+                    }
+                    assert(term_b == edwards_neg(
+                        projective_niels_point_as_affine_edwards(selected_B),
+                    )) by {
+                        lemma_neg_of_signed_scalar_mul(B_affine, abs_digit as int);
+                        assert(digit as int == -(abs_digit as int));
+                    }
+                    assert(col_ab == edwards_add(col_a.0, col_a.1, term_b.0, term_b.1)) by {
+                        lemma_vt_double_base_col_ab(
+                            A_affine,
+                            B_affine,
+                            a_naf@,
+                            b_naf@,
+                            pts_affine,
+                            nafs,
+                            i as int,
+                        );
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    )) by {
+                        axiom_edwards_add_associative(
+                            doubled_affine.0,
+                            doubled_affine.1,
+                            col_a.0,
+                            col_a.1,
+                            term_b.0,
+                            term_b.1,
+                        );
+                    }
+                }
+            },
+            Ordering::Equal => {
+                proof {
+                    assert(col_ab == col_a) by {
+                        lemma_column_sum_canonical(pts_affine, nafs, i as int, 1);
+                        lemma_column_sum_step_zero_digit(pts_affine, nafs, i as int, 1);
+                    }
+                    assert(completed_point_as_affine_edwards(t) == edwards_add(
+                        doubled_affine.0,
+                        doubled_affine.1,
+                        col_ab.0,
+                        col_ab.1,
+                    ));
+                }
+            },
         }
 
         r = t.as_projective();
 
-        if i == 0 {
-            break ;
+        proof {
+            lemma_straus_vt_step(pts_affine, nafs, i as int);
         }
-        i -= 1;
     }
 
-    assume(false);  // PROOF BYPASS: precondition for as_extended
-    let result = r.as_extended();
     proof {
-        // PROOF BYPASS: postconditions
-        assume(is_well_formed_edwards_point(result));
-        assume(edwards_point_as_affine(result) == {
-            let aA = edwards_scalar_mul(edwards_point_as_affine(*A), scalar_as_nat(a));
-            let bB = edwards_scalar_mul(spec_ed25519_basepoint(), scalar_as_nat(b));
-            edwards_add(aA.0, aA.1, bB.0, bB.1)
-        });
+        crate::lemmas::field_lemmas::add_lemmas::lemma_fe51_limbs_bounded_weaken(&r.X, 52, 54);
+        crate::lemmas::field_lemmas::add_lemmas::lemma_fe51_limbs_bounded_weaken(&r.Y, 52, 54);
+        crate::lemmas::field_lemmas::add_lemmas::lemma_fe51_limbs_bounded_weaken(&r.Z, 52, 54);
+    }
+    let result = r.as_extended();
+
+    proof {
+        assert(reconstruct(a_naf@) == scalar_as_nat(a) as int);
+        assert(reconstruct(b_naf@) == scalar_as_nat(b) as int);
+
+        // Help Z3 with seq operations
+        assert(pts_affine.drop_last() == seq![A_affine]);
+        assert(nafs.drop_last() == seq![a_naf@]);
+        assert(pts_affine.last() == B_affine);
+        assert(nafs.last() == b_naf@);
+
+        lemma_straus_vt_partial_peel_last(pts_affine, nafs, 0);
+
+        // A-part
+        lemma_straus_vt_single(A_affine, a_naf@, 0);
+        lemma_reconstruct_naf_from_equals_reconstruct(a_naf@);
+        assert(straus_vt_partial(seq![A_affine], seq![a_naf@], 0) == edwards_scalar_mul_signed(
+            A_affine,
+            scalar_as_nat(a) as int,
+        ));
+
+        // B-part
+        lemma_straus_vt_single(B_affine, b_naf@, 0);
+        lemma_reconstruct_naf_from_equals_reconstruct(b_naf@);
+        assert(straus_vt_partial(seq![B_affine], seq![b_naf@], 0) == edwards_scalar_mul_signed(
+            B_affine,
+            scalar_as_nat(b) as int,
+        ));
+
+        // signed -> unsigned since scalars are non-negative
+        assert(edwards_scalar_mul_signed(A_affine, scalar_as_nat(a) as int) == edwards_scalar_mul(
+            A_affine,
+            scalar_as_nat(a),
+        )) by {
+            reveal(edwards_scalar_mul_signed);
+        }
+        assert(edwards_scalar_mul_signed(B_affine, scalar_as_nat(b) as int) == edwards_scalar_mul(
+            B_affine,
+            scalar_as_nat(b),
+        )) by {
+            reveal(edwards_scalar_mul_signed);
+        }
+
+        assert(edwards_point_as_affine(result) == projective_point_as_affine_edwards(r));
+        assert(is_well_formed_edwards_point(result));
     }
     result
 }

--- a/curve25519-dalek/src/lemmas/edwards_lemmas/mod.rs
+++ b/curve25519-dalek/src/lemmas/edwards_lemmas/mod.rs
@@ -20,3 +20,4 @@ pub mod niels_addition_correctness;
 pub mod pippenger_lemmas;
 pub mod step1_lemmas;
 pub mod straus_lemmas;
+pub mod vartime_double_base_lemmas;

--- a/curve25519-dalek/src/lemmas/edwards_lemmas/vartime_double_base_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/edwards_lemmas/vartime_double_base_lemmas.rs
@@ -1,0 +1,271 @@
+//! Lemmas for vartime_double_base scalar multiplication: aA + bB.
+//!
+//! Proves correctness of `vartime_double_base::mul` which computes aA + bB
+//! where B is the Ed25519 basepoint, using Straus variable-time evaluation
+//! with NAF(5) for A and NAF(8) for B (precomputed-tables) or NAF(5) for both.
+//!
+//! ## Bundled validity predicate:
+//! - `vt_double_base_input_valid`: groups table bounds, NAF validity, and point coordinates
+//!
+//! ## Select lemmas (precomputed-tables):
+//! - `lemma_naf_select_is_signed_scalar_mul_affine8`: NafLookupTable8 select -> \[d\] B
+//! - `lemma_naf_digit_positive_select_preconditions_8`: bit-vector preconditions for positive NAF(8) digit
+//! - `lemma_naf_digit_negative_select_preconditions_8`: bit-vector preconditions for negative NAF(8) digit
+//!
+//! ## Column sum helpers:
+//! - `lemma_vt_double_base_col_a`: column sum after processing digit a
+//! - `lemma_vt_double_base_col_ab`: column sum after processing digits a and b
+//!
+//! ## Axioms:
+//! - `axiom_affine_odd_multiples_entries_valid`: each entry of a valid NAF(8) table is a valid AffineNielsPoint
+#![allow(non_snake_case)]
+
+#[cfg(feature = "precomputed-tables")]
+use crate::backend::serial::curve_models::AffineNielsPoint;
+use crate::backend::serial::curve_models::ProjectiveNielsPoint;
+
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::lemmas::edwards_lemmas::curve_equation_lemmas::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::lemmas::edwards_lemmas::straus_lemmas::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::edwards_specs::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::field_specs::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::field_specs_u64::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::scalar_specs::*;
+#[cfg(verus_keep_ghost)]
+#[allow(unused_imports)]
+use crate::specs::window_specs::*;
+
+use vstd::prelude::*;
+
+verus! {
+
+// ============================================================================
+// Select lemmas (precomputed-tables)
+// ============================================================================
+/// For precomputed tables: select from 64-entry AffineNiels table
+#[cfg(feature = "precomputed-tables")]
+pub proof fn lemma_naf_select_is_signed_scalar_mul_affine8(
+    table: [AffineNielsPoint; 64],
+    digit: i8,
+    result: AffineNielsPoint,
+    basepoint: (nat, nat),
+)
+    requires
+        0 < digit < 128,
+        (digit as int) % 2 != 0,
+        forall|j: int|
+            0 <= j < 64 ==> affine_niels_point_as_affine_edwards(#[trigger] table[j])
+                == edwards_scalar_mul(basepoint, (2 * j + 1) as nat),
+        result == table[((digit as int) / 2) as int],
+    ensures
+        affine_niels_point_as_affine_edwards(result) == edwards_scalar_mul_signed(
+            basepoint,
+            digit as int,
+        ),
+{
+    reveal(edwards_scalar_mul_signed);
+    let j = ((digit as int) / 2) as int;
+    assert(0 <= j < 64);
+    assert(affine_niels_point_as_affine_edwards(table[j]) == edwards_scalar_mul(
+        basepoint,
+        (2 * j + 1) as nat,
+    ));
+    assert((2 * j + 1) as nat == digit as nat);
+}
+
+/// For a NAF digit d > 0 from a valid NAF(8), d is odd and d < 128.
+#[cfg(feature = "precomputed-tables")]
+pub proof fn lemma_naf_digit_positive_select_preconditions_8(digit: i8)
+    requires
+        digit > 0,
+        (digit as int) % 2 != 0,
+        digit < 128,
+    ensures
+        (digit as usize) & 1usize == 1usize,
+        (digit as usize) < 128,
+{
+    assert((digit as usize) & 1usize == 1usize) by (bit_vector)
+        requires
+            digit > 0i8,
+            digit <= 127i8,
+            (digit as int) % 2 != 0,
+    ;
+}
+
+/// For a NAF digit d < 0 from a valid NAF(8), -d is odd and -d < 128.
+#[cfg(feature = "precomputed-tables")]
+pub proof fn lemma_naf_digit_negative_select_preconditions_8(digit: i8)
+    requires
+        digit < 0,
+        (digit as int) % 2 != 0,
+        digit > -128,
+    ensures
+        ((-digit) as usize) & 1usize == 1usize,
+        ((-digit) as usize) < 128,
+{
+    assert(((-digit) as usize) & 1usize == 1usize) by (bit_vector)
+        requires
+            digit < 0i8,
+            digit > -128i8,
+            (digit as int) % 2 != 0,
+    ;
+}
+
+// ============================================================================
+// Axioms
+// ============================================================================
+/// Axiom: each entry in a valid NAF lookup table (width 8) is a valid AffineNielsPoint.
+#[cfg(feature = "precomputed-tables")]
+pub proof fn axiom_affine_odd_multiples_entries_valid(
+    table: [AffineNielsPoint; 64],
+    basepoint: (nat, nat),
+    idx: int,
+)
+    requires
+        0 <= idx < 64,
+        naf_lookup_table8_affine_limbs_bounded(table),
+        is_valid_naf_lookup_table8_affine_coords(table, basepoint),
+    ensures
+        is_valid_affine_niels_point(table[idx]),
+{
+    admit();
+}
+
+// ============================================================================
+// Bundled predicates
+// ============================================================================
+#[cfg(feature = "precomputed-tables")]
+pub open spec fn vt_double_base_input_valid(
+    a_naf: Seq<i8>,
+    b_naf: Seq<i8>,
+    table_A: [ProjectiveNielsPoint; 8],
+    table_B: [AffineNielsPoint; 64],
+    A_affine: (nat, nat),
+    B_affine: (nat, nat),
+    pts_affine: Seq<(nat, nat)>,
+    nafs: Seq<Seq<i8>>,
+) -> bool {
+    &&& pts_affine == seq![A_affine, B_affine]
+    &&& nafs == seq![a_naf, b_naf]
+    &&& pts_affine.len() == 2
+    &&& nafs.len() == 2
+    &&& A_affine.0 < p()
+    &&& A_affine.1 < p()
+    &&& B_affine.0 < p()
+    &&& B_affine.1 < p()
+    &&& a_naf.len() == 256
+    &&& b_naf.len() == 256
+    &&& is_valid_naf(a_naf, 5)
+    &&& is_valid_naf(b_naf, 8)
+    &&& naf_lookup_table5_projective_limbs_bounded(table_A)
+    &&& forall|j: int| 0 <= j < 8 ==> is_valid_projective_niels_point(#[trigger] table_A[j])
+    &&& forall|j: int|
+        0 <= j < 8 ==> projective_niels_point_as_affine_edwards(#[trigger] table_A[j])
+            == edwards_scalar_mul(A_affine, (2 * j + 1) as nat)
+    &&& naf_lookup_table8_affine_limbs_bounded(table_B)
+    &&& is_valid_naf_lookup_table8_affine_coords(table_B, B_affine)
+}
+
+#[cfg(not(feature = "precomputed-tables"))]
+pub open spec fn vt_double_base_input_valid(
+    a_naf: Seq<i8>,
+    b_naf: Seq<i8>,
+    table_A: [ProjectiveNielsPoint; 8],
+    table_B: [ProjectiveNielsPoint; 8],
+    A_affine: (nat, nat),
+    B_affine: (nat, nat),
+    pts_affine: Seq<(nat, nat)>,
+    nafs: Seq<Seq<i8>>,
+) -> bool {
+    &&& pts_affine == seq![A_affine, B_affine]
+    &&& nafs == seq![a_naf, b_naf]
+    &&& pts_affine.len() == 2
+    &&& nafs.len() == 2
+    &&& A_affine.0 < p()
+    &&& A_affine.1 < p()
+    &&& B_affine.0 < p()
+    &&& B_affine.1 < p()
+    &&& a_naf.len() == 256
+    &&& b_naf.len() == 256
+    &&& is_valid_naf(a_naf, 5)
+    &&& is_valid_naf(b_naf, 5)
+    &&& naf_lookup_table5_projective_limbs_bounded(table_A)
+    &&& forall|j: int| 0 <= j < 8 ==> is_valid_projective_niels_point(#[trigger] table_A[j])
+    &&& forall|j: int|
+        0 <= j < 8 ==> projective_niels_point_as_affine_edwards(#[trigger] table_A[j])
+            == edwards_scalar_mul(A_affine, (2 * j + 1) as nat)
+    &&& naf_lookup_table5_projective_limbs_bounded(table_B)
+    &&& forall|j: int| 0 <= j < 8 ==> is_valid_projective_niels_point(#[trigger] table_B[j])
+    &&& forall|j: int|
+        0 <= j < 8 ==> projective_niels_point_as_affine_edwards(#[trigger] table_B[j])
+            == edwards_scalar_mul(B_affine, (2 * j + 1) as nat)
+}
+
+// ============================================================================
+// Column sum helpers
+// ============================================================================
+pub proof fn lemma_vt_double_base_col_a(
+    A_affine: (nat, nat),
+    B_affine: (nat, nat),
+    a_naf: Seq<i8>,
+    b_naf: Seq<i8>,
+    pts_affine: Seq<(nat, nat)>,
+    nafs: Seq<Seq<i8>>,
+    i: int,
+)
+    requires
+        pts_affine == seq![A_affine, B_affine],
+        nafs == seq![a_naf, b_naf],
+        A_affine.0 < p(),
+        A_affine.1 < p(),
+        a_naf.len() == 256,
+        0 <= i < 256,
+    ensures
+        straus_column_sum(pts_affine, nafs, i, 1) == edwards_scalar_mul_signed(
+            A_affine,
+            a_naf[i] as int,
+        ),
+{
+    lemma_column_sum_single(A_affine, a_naf, i);
+    lemma_column_sum_prefix_eq(seq![A_affine], seq![a_naf], pts_affine, nafs, i, 1);
+}
+
+pub proof fn lemma_vt_double_base_col_ab(
+    A_affine: (nat, nat),
+    B_affine: (nat, nat),
+    a_naf: Seq<i8>,
+    b_naf: Seq<i8>,
+    pts_affine: Seq<(nat, nat)>,
+    nafs: Seq<Seq<i8>>,
+    i: int,
+)
+    requires
+        pts_affine == seq![A_affine, B_affine],
+        nafs == seq![a_naf, b_naf],
+        b_naf.len() == 256,
+        0 <= i < 256,
+    ensures
+        straus_column_sum(pts_affine, nafs, i, 2) == edwards_add(
+            straus_column_sum(pts_affine, nafs, i, 1).0,
+            straus_column_sum(pts_affine, nafs, i, 1).1,
+            edwards_scalar_mul_signed(B_affine, b_naf[i] as int).0,
+            edwards_scalar_mul_signed(B_affine, b_naf[i] as int).1,
+        ),
+{
+    reveal(straus_column_sum);
+    assert(pts_affine[1] == B_affine);
+    assert(nafs[1] == b_naf);
+}
+
+} // verus!


### PR DESCRIPTION
Replace assume(false) proof bypass with a complete Verus proof of vartime_double_base::mul, which computes aA + bB where B is the Ed25519 basepoint using Straus variable-time evaluation with NAF representations.

Key changes:
- Restructure loop from loop/break to while i > 0 for Verus
- Add bundled predicate vt_double_base_input_valid
- Add column sum helpers (lemma_vt_double_base_col_a/ab)
- Add NAF(8) select lemmas for precomputed AffineNiels tables
- Add axiom_affine_odd_multiples_entries_valid for table entry validity
- Strengthen AffineNielsPoint sub postcondition with fe51_limbs_bounded
- Scope all expensive lemma calls in assert-by blocks (rlimit 50)

Supports both precomputed-tables (NAF8, 64-entry AffineNiels) and non-precomputed (NAF5, 8-entry ProjectiveNiels) configurations.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Source code modifications **highlighted and justified**
- [ ] Proof cheats (`assume(false)`, `sorry`, etc.) **highlighted and justified**
