### PR TITLE
ci: switch probe-verus to main branch

### DIFF
--- a/.github/actions/setup-probe-verus/action.yml
+++ b/.github/actions/setup-probe-verus/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: |
         set -e
-        SHA=$(git ls-remote https://github.com/Beneficial-AI-Foundation/probe-verus.git refs/heads/include-external-body | cut -f1)
+        SHA=$(git ls-remote https://github.com/Beneficial-AI-Foundation/probe-verus.git HEAD | cut -f1)
         if [ -z "$SHA" ]; then
           echo "Error: Failed to fetch probe-verus commit SHA" >&2
           exit 1
@@ -30,4 +30,4 @@ runs:
       if: steps.cache-probe-verus.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        cargo install --git https://github.com/Beneficial-AI-Foundation/probe-verus.git --branch include-external-body
+        cargo install --git https://github.com/Beneficial-AI-Foundation/probe-verus.git


### PR DESCRIPTION
## Summary

- Switch `setup-probe-verus` action from the `include-external-body` feature branch back to `main`, now that [probe-verus#19](https://github.com/Beneficial-AI-Foundation/probe-verus/pull/19) has been merged.

## Test plan

- [ ] CI deploys website successfully using probe-verus from `main`


Made with [Cursor](https://cursor.com)