### PR TITLE
Remove daily schedule from callgraph workflow

### DIFF
--- a/.github/workflows/generate-callgraph.yml
+++ b/.github/workflows/generate-callgraph.yml
@@ -10,9 +10,6 @@ on:
       - 'curve25519-dalek/Cargo.toml'
       - '.github/workflows/generate-callgraph.yml'
       - '.github/data/focus_dalek_entrypoints.json'
-  schedule:
-    # Run daily at 6:00 UTC to keep cache fresh (caches expire after 7 days of no access)
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 # Only allow one callgraph generation at a time


### PR DESCRIPTION
## Summary

- Removes the `schedule` trigger (daily cron at 6:00 UTC) from the callgraph workflow
- The schedule was originally added to keep GitHub Actions caches warm (they expire after 7 days of no access)
- Since the project is considered done, the periodic cache refresh is unnecessary waste of CI minutes

The workflow still triggers on pushes to main and via manual `workflow_dispatch`.

Made with [Cursor](https://cursor.com)