### PR TITLE
Mark spec-less out-of-scope functions #[verifier::external]

### DIFF
--- a/curve25519-dalek/src/backend/mod.rs
+++ b/curve25519-dalek/src/backend/mod.rs
@@ -94,6 +94,7 @@ fn get_selected_backend() -> (result: BackendKind)
 } // verus!
 #[allow(missing_docs)]
 #[cfg(feature = "alloc")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 pub fn pippenger_optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<EdwardsPoint>
 where
     I: IntoIterator,
@@ -130,6 +131,7 @@ pub(crate) enum VartimePrecomputedStraus {
 
 #[cfg(feature = "alloc")]
 impl VartimePrecomputedStraus {
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     pub fn new<I>(static_points: I) -> Self
     where
         I: IntoIterator,
@@ -152,6 +154,7 @@ impl VartimePrecomputedStraus {
         }
     }
 
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     pub fn optional_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,
@@ -191,6 +194,7 @@ impl VartimePrecomputedStraus {
 
 #[allow(missing_docs)]
 #[cfg(feature = "alloc")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 pub fn straus_multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
 where
     I: IntoIterator,
@@ -219,6 +223,7 @@ where
 
 #[allow(missing_docs)]
 #[cfg(feature = "alloc")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 pub fn straus_optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<EdwardsPoint>
 where
     I: IntoIterator,

--- a/curve25519-dalek/src/backend/serial/curve_models/mod.rs
+++ b/curve25519-dalek/src/backend/serial/curve_models/mod.rs
@@ -2047,6 +2047,7 @@ impl<'a> Neg for &'a AffineNielsPoint {
 // ------------------------------------------------------------------------
 // Debug traits
 // ------------------------------------------------------------------------
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for ProjectivePoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -2057,6 +2058,7 @@ impl Debug for ProjectivePoint {
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for CompletedPoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -2067,6 +2069,7 @@ impl Debug for CompletedPoint {
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for AffineNielsPoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -2077,6 +2080,7 @@ impl Debug for AffineNielsPoint {
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for ProjectiveNielsPoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ProjectiveNielsPoint{{\n\tY_plus_X: {:?},\n\tY_minus_X: {:?},\n\tZ: {:?},\n\tT2d: {:?}\n}}",

--- a/curve25519-dalek/src/backend/serial/scalar_mul/pippenger.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/pippenger.rs
@@ -94,6 +94,7 @@ pub use crate::specs::iterator_specs::{
 /// This algorithm is adapted from section 4 of <https://eprint.iacr.org/2012/549.pdf>.
 pub struct Pippenger;
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl VartimeMultiscalarMul for Pippenger {
     type Point = EdwardsPoint;
 

--- a/curve25519-dalek/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -28,6 +28,7 @@ pub struct VartimePrecomputedStraus {
     static_lookup_tables: Vec<NafLookupTable8<AffineNielsPoint>>,
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
     type Point = EdwardsPoint;
 

--- a/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
@@ -81,6 +81,7 @@ use crate::specs::iterator_specs::{
 /// [problem]: https://www.jstor.org/stable/2312273
 pub struct Straus {}
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl MultiscalarMul for Straus {
     type Point = EdwardsPoint;
 
@@ -190,6 +191,7 @@ impl MultiscalarMul for Straus {
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl VartimeMultiscalarMul for Straus {
     type Point = EdwardsPoint;
 

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -115,11 +115,11 @@ pub struct FieldElement51 {
     pub limbs: [u64; 5],
 }
 
+#[verifier::external]
 impl Debug for FieldElement51 {
     /* VERIFICATION NOTE: we don't cover debugging */
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `core::fmt::Debug::fmt` (for FieldElement51)
-    #[verifier::external_body]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "FieldElement51({:?})", &self.limbs[..])
     }

--- a/curve25519-dalek/src/backend/serial/u64/scalar.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar.rs
@@ -98,6 +98,7 @@ pub struct Scalar52 {
 }
 
 } // verus!
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for Scalar52 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Scalar52: {:?}", self.limbs)
@@ -135,6 +136,7 @@ impl Index<usize> for Scalar52 {
 
 } // verus!
 // VERIFICATION EXCLUDED: mutable returns unsupported by Verus
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl IndexMut<usize> for Scalar52 {
     fn index_mut(&mut self, _index: usize) -> &mut u64 {
         &mut (self.limbs[_index])

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -683,7 +683,6 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "serde")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Serialize for EdwardsPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -714,7 +713,6 @@ impl Serialize for CompressedEdwardsY {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<'de> Deserialize<'de> for EdwardsPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -722,7 +720,6 @@ impl<'de> Deserialize<'de> for EdwardsPoint {
     {
         struct EdwardsPointVisitor;
 
-        #[cfg_attr(verus_keep_ghost, verifier::external)]
         impl<'de> Visitor<'de> for EdwardsPointVisitor {
             type Value = EdwardsPoint;
 
@@ -3981,7 +3978,6 @@ impl Debug for EdwardsPoint {
 // Use the full trait path to avoid Group::identity overlapping Identity::identity in the
 // rest of the module (e.g. tests).
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl group::Group for EdwardsPoint {
     type Scalar = Scalar;
 
@@ -4015,7 +4011,6 @@ impl group::Group for EdwardsPoint {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl GroupEncoding for EdwardsPoint {
     type Repr = [u8; 32];
 
@@ -4042,7 +4037,6 @@ impl GroupEncoding for EdwardsPoint {
 pub struct SubgroupPoint(EdwardsPoint);
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl From<SubgroupPoint> for EdwardsPoint {
     fn from(p: SubgroupPoint) -> Self {
         p.0
@@ -4050,7 +4044,6 @@ impl From<SubgroupPoint> for EdwardsPoint {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Neg for SubgroupPoint {
     type Output = Self;
 
@@ -4060,7 +4053,6 @@ impl Neg for SubgroupPoint {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Add<&SubgroupPoint> for &SubgroupPoint {
     type Output = SubgroupPoint;
     fn add(self, other: &SubgroupPoint) -> SubgroupPoint {
@@ -4091,7 +4083,6 @@ define_add_variants!(
 );
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl AddAssign<&SubgroupPoint> for SubgroupPoint {
     fn add_assign(&mut self, rhs: &SubgroupPoint) {
         self.0 += rhs.0
@@ -4112,7 +4103,6 @@ impl AddAssign<&SubgroupPoint> for EdwardsPoint {
 define_add_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Sub<&SubgroupPoint> for &SubgroupPoint {
     type Output = SubgroupPoint;
     fn sub(self, other: &SubgroupPoint) -> SubgroupPoint {
@@ -4143,7 +4133,6 @@ define_sub_variants!(
 );
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl SubAssign<&SubgroupPoint> for SubgroupPoint {
     fn sub_assign(&mut self, rhs: &SubgroupPoint) {
         self.0 -= rhs.0;
@@ -4164,7 +4153,6 @@ impl SubAssign<&SubgroupPoint> for EdwardsPoint {
 define_sub_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T> Sum<T> for SubgroupPoint
 where
     T: Borrow<SubgroupPoint>,
@@ -4179,7 +4167,6 @@ where
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Mul<&Scalar> for &SubgroupPoint {
     type Output = SubgroupPoint;
 
@@ -4212,7 +4199,6 @@ impl Mul<&SubgroupPoint> for &Scalar {
 define_mul_variants!(LHS = SubgroupPoint, RHS = Scalar, Output = SubgroupPoint);
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl MulAssign<&Scalar> for SubgroupPoint {
     fn mul_assign(&mut self, scalar: &Scalar) {
         self.0 *= scalar;
@@ -4281,7 +4267,6 @@ impl PrimeGroup for SubgroupPoint {}
 
 /// Ristretto has a cofactor of 1.
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl CofactorGroup for EdwardsPoint {
     type Subgroup = SubgroupPoint;
 

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -2360,9 +2360,8 @@ impl EdwardsPoint {
     /// This is used for exec correctness/performance, but is not verified directly.
     /// The verified implementation is `Sum::sum` below, which reduces to `sum_of_slice`.
     /// Functional equivalence is tested in `mod test_sum` (at the bottom of this file).
-    /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
-    /// `core::iter::Iterator::fold` (original Sum impl for EdwardsPoint)
-    #[verifier::external_body]
+    /// Out of verification scope: no verified caller (only `mod test_sum` uses it).
+    #[verifier::external]
     pub fn sum_original<T, I>(iter: I) -> (result: EdwardsPoint) where
         T: Borrow<EdwardsPoint>,
         I: Iterator<Item = T>,

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -244,11 +244,11 @@ impl ConstantTimeEq for CompressedEdwardsY {
     }
 }
 
+#[verifier::external]
 impl Debug for CompressedEdwardsY {
     /* VERIFICATION NOTE: we don't cover debugging */
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `core::fmt::Debug::fmt` (for CompressedEdwardsY)
-    #[verifier::external_body]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CompressedEdwardsY: {:?}", self.as_bytes())
     }
@@ -2715,12 +2715,12 @@ impl EdwardsPoint {
 // These use the iterator's size hint and the target settings to
 // forward to a specific backend implementation.
 #[cfg(feature = "alloc")]
+#[verifier::external]
 impl MultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `MultiscalarMul::multiscalar_mul` (for EdwardsPoint, see verified `multiscalar_mul_verus`)
-    #[verifier::external_body]
     fn multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -2759,12 +2759,12 @@ impl MultiscalarMul for EdwardsPoint {
 }
 
 #[cfg(feature = "alloc")]
+#[verifier::external]
 impl VartimeMultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `VartimeMultiscalarMul::optional_multiscalar_mul` (for EdwardsPoint, see verified `optional_multiscalar_mul_verus`)
-    #[verifier::external_body]
     fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<EdwardsPoint> where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -683,6 +683,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "serde")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Serialize for EdwardsPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -713,6 +714,7 @@ impl Serialize for CompressedEdwardsY {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<'de> Deserialize<'de> for EdwardsPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -720,6 +722,7 @@ impl<'de> Deserialize<'de> for EdwardsPoint {
     {
         struct EdwardsPointVisitor;
 
+        #[cfg_attr(verus_keep_ghost, verifier::external)]
         impl<'de> Visitor<'de> for EdwardsPointVisitor {
             type Value = EdwardsPoint;
 
@@ -2815,6 +2818,7 @@ impl VartimeMultiscalarMul for EdwardsPoint {
 pub struct VartimeEdwardsPrecomputation(crate::backend::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl VartimePrecomputedMultiscalarMul for VartimeEdwardsPrecomputation {
     type Point = EdwardsPoint;
 
@@ -3725,6 +3729,7 @@ impl<'a, 'b> Mul<&'a EdwardsBasepointTable> for &'b Scalar {
 }
 
 } // verus!
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for EdwardsBasepointTable {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}([\n", stringify!(EdwardsBasepointTable))?;
@@ -3958,6 +3963,7 @@ impl EdwardsPoint {
 // ------------------------------------------------------------------------
 // Debug traits
 // ------------------------------------------------------------------------
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for EdwardsPoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -3975,6 +3981,7 @@ impl Debug for EdwardsPoint {
 // Use the full trait path to avoid Group::identity overlapping Identity::identity in the
 // rest of the module (e.g. tests).
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl group::Group for EdwardsPoint {
     type Scalar = Scalar;
 
@@ -4008,6 +4015,7 @@ impl group::Group for EdwardsPoint {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl GroupEncoding for EdwardsPoint {
     type Repr = [u8; 32];
 
@@ -4034,6 +4042,7 @@ impl GroupEncoding for EdwardsPoint {
 pub struct SubgroupPoint(EdwardsPoint);
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl From<SubgroupPoint> for EdwardsPoint {
     fn from(p: SubgroupPoint) -> Self {
         p.0
@@ -4041,6 +4050,7 @@ impl From<SubgroupPoint> for EdwardsPoint {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Neg for SubgroupPoint {
     type Output = Self;
 
@@ -4050,6 +4060,7 @@ impl Neg for SubgroupPoint {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Add<&SubgroupPoint> for &SubgroupPoint {
     type Output = SubgroupPoint;
     fn add(self, other: &SubgroupPoint) -> SubgroupPoint {
@@ -4080,6 +4091,7 @@ define_add_variants!(
 );
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl AddAssign<&SubgroupPoint> for SubgroupPoint {
     fn add_assign(&mut self, rhs: &SubgroupPoint) {
         self.0 += rhs.0
@@ -4100,6 +4112,7 @@ impl AddAssign<&SubgroupPoint> for EdwardsPoint {
 define_add_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Sub<&SubgroupPoint> for &SubgroupPoint {
     type Output = SubgroupPoint;
     fn sub(self, other: &SubgroupPoint) -> SubgroupPoint {
@@ -4130,6 +4143,7 @@ define_sub_variants!(
 );
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl SubAssign<&SubgroupPoint> for SubgroupPoint {
     fn sub_assign(&mut self, rhs: &SubgroupPoint) {
         self.0 -= rhs.0;
@@ -4150,6 +4164,7 @@ impl SubAssign<&SubgroupPoint> for EdwardsPoint {
 define_sub_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T> Sum<T> for SubgroupPoint
 where
     T: Borrow<SubgroupPoint>,
@@ -4164,6 +4179,7 @@ where
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Mul<&Scalar> for &SubgroupPoint {
     type Output = SubgroupPoint;
 
@@ -4196,6 +4212,7 @@ impl Mul<&SubgroupPoint> for &Scalar {
 define_mul_variants!(LHS = SubgroupPoint, RHS = Scalar, Output = SubgroupPoint);
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl MulAssign<&Scalar> for SubgroupPoint {
     fn mul_assign(&mut self, scalar: &Scalar) {
         self.0 *= scalar;
@@ -4264,6 +4281,7 @@ impl PrimeGroup for SubgroupPoint {}
 
 /// Ristretto has a cofactor of 1.
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl CofactorGroup for EdwardsPoint {
     type Subgroup = SubgroupPoint;
 

--- a/curve25519-dalek/src/lizard/u32_constants.rs
+++ b/curve25519-dalek/src/lizard/u32_constants.rs
@@ -4,7 +4,6 @@ cfg_if! {
     if #[cfg(curve25519_dalek_backend = "fiat")] {
         pub use crate::backend::serial::fiat_u32::field::FieldElement2625;
 
-        #[cfg_attr(verus_keep_ghost, verifier::external)]
         const fn field_element(element: [u32; 10]) -> FieldElement2625 {
             FieldElement2625(fiat_crypto::curve25519_32::fiat_25519_tight_field_element(element))
         }

--- a/curve25519-dalek/src/lizard/u32_constants.rs
+++ b/curve25519-dalek/src/lizard/u32_constants.rs
@@ -4,6 +4,7 @@ cfg_if! {
     if #[cfg(curve25519_dalek_backend = "fiat")] {
         pub use crate::backend::serial::fiat_u32::field::FieldElement2625;
 
+        #[cfg_attr(verus_keep_ghost, verifier::external)]
         const fn field_element(element: [u32; 10]) -> FieldElement2625 {
             FieldElement2625(fiat_crypto::curve25519_32::fiat_25519_tight_field_element(element))
         }

--- a/curve25519-dalek/src/lizard/u64_constants.rs
+++ b/curve25519-dalek/src/lizard/u64_constants.rs
@@ -3,6 +3,7 @@ pub use crate::backend::serial::u64::field::FieldElement51;
 // Verus cannot use const fn: not supported inside verus!, and calls to
 // functions outside verus! are rejected as "external".
 #[allow(dead_code)]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 const fn field_element(element: [u64; 5]) -> FieldElement51 {
     FieldElement51 { limbs: element }
 }

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -3212,9 +3212,8 @@ impl RistrettoPoint {
     /// This is used for exec correctness/performance, but is not verified directly.
     /// The verified implementation is `Sum::sum` below, which reduces to `sum_of_slice`.
     /// Functional equivalence is tested in `mod test_sum` (at the bottom of this file).
-    /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
-    /// `core::iter::Iterator::fold` (original Sum impl for RistrettoPoint)
-    #[verifier::external_body]
+    /// Out of verification scope: no verified caller (only `mod test_sum` uses it).
+    #[verifier::external]
     pub fn sum_original<T, I>(iter: I) -> (result: RistrettoPoint) where
         T: Borrow<RistrettoPoint>,
         I: Iterator<Item = T>,

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -958,6 +958,7 @@ impl Default for CompressedRistretto {
 }
 
 } // verus!
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl TryFrom<&[u8]> for CompressedRistretto {
     type Error = TryFromSliceError;
 
@@ -980,6 +981,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "serde")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Serialize for RistrettoPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1010,6 +1012,7 @@ impl Serialize for CompressedRistretto {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<'de> Deserialize<'de> for RistrettoPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1017,6 +1020,7 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
     {
         struct RistrettoPointVisitor;
 
+        #[cfg_attr(verus_keep_ghost, verifier::external)]
         impl<'de> Visitor<'de> for RistrettoPointVisitor {
             type Value = RistrettoPoint;
 
@@ -3687,6 +3691,7 @@ impl RistrettoPoint {
 pub struct VartimeRistrettoPrecomputation(crate::backend::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl VartimePrecomputedMultiscalarMul for VartimeRistrettoPrecomputation {
     type Point = RistrettoPoint;
 
@@ -3884,12 +3889,14 @@ impl ConditionallySelectable for RistrettoPoint {
 // ------------------------------------------------------------------------
 // Debug traits
 // ------------------------------------------------------------------------
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for CompressedRistretto {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CompressedRistretto: {:?}", self.as_bytes())
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Debug for RistrettoPoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let coset = self.coset4();
@@ -3908,6 +3915,7 @@ impl Debug for RistrettoPoint {
 // Use the full trait path to avoid Group::identity overlapping Identity::identity in the
 // rest of the module (e.g. tests).
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl group::Group for RistrettoPoint {
     type Scalar = Scalar;
 
@@ -3936,6 +3944,7 @@ impl group::Group for RistrettoPoint {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl GroupEncoding for RistrettoPoint {
     type Repr = [u8; 32];
 
@@ -3965,6 +3974,7 @@ impl PrimeGroup for RistrettoPoint {}
 
 /// Ristretto has a cofactor of 1.
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl CofactorGroup for RistrettoPoint {
     type Subgroup = Self;
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -981,7 +981,6 @@ use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "serde")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Serialize for RistrettoPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1012,7 +1011,6 @@ impl Serialize for CompressedRistretto {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<'de> Deserialize<'de> for RistrettoPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1020,7 +1018,6 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
     {
         struct RistrettoPointVisitor;
 
-        #[cfg_attr(verus_keep_ghost, verifier::external)]
         impl<'de> Visitor<'de> for RistrettoPointVisitor {
             type Value = RistrettoPoint;
 
@@ -3915,7 +3912,6 @@ impl Debug for RistrettoPoint {
 // Use the full trait path to avoid Group::identity overlapping Identity::identity in the
 // rest of the module (e.g. tests).
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl group::Group for RistrettoPoint {
     type Scalar = Scalar;
 
@@ -3944,7 +3940,6 @@ impl group::Group for RistrettoPoint {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl GroupEncoding for RistrettoPoint {
     type Repr = [u8; 32];
 
@@ -3974,7 +3969,6 @@ impl PrimeGroup for RistrettoPoint {}
 
 /// Ristretto has a cofactor of 1.
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl CofactorGroup for RistrettoPoint {
     type Subgroup = Self;
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -2709,7 +2709,7 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
-    #[verifier::external_body]
+    #[verifier::external]
     pub fn random<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
         let mut uniform_bytes = [0u8;64];
         rng.fill_bytes(&mut uniform_bytes);
@@ -3511,12 +3511,12 @@ define_ristretto_scalar_mul_variants_verus!();
 verus! {
 
 #[cfg(feature = "alloc")]
+#[verifier::external]
 impl MultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `MultiscalarMul::multiscalar_mul` (for RistrettoPoint, delegates to EdwardsPoint)
-    #[verifier::external_body]
     fn multiscalar_mul<I, J>(scalars: I, points: J) -> RistrettoPoint where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -3529,12 +3529,12 @@ impl MultiscalarMul for RistrettoPoint {
 }
 
 #[cfg(feature = "alloc")]
+#[verifier::external]
 impl VartimeMultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `VartimeMultiscalarMul::optional_multiscalar_mul` (for RistrettoPoint, delegates to EdwardsPoint)
-    #[verifier::external_body]
     fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<RistrettoPoint> where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -417,7 +417,6 @@ impl Scalar {
         since = "4.0.0",
         note = "This constructor outputs scalars with undefined scalar-scalar arithmetic. See docs."
     )]
-    #[cfg_attr(verus_keep_ghost, verifier::external)]
     pub const fn from_bits(bytes: [u8; 32]) -> Scalar {
         let mut s = Scalar { bytes };
         // Ensure invariant #1 holds. That is, make s < 2^255 by masking the high bit.
@@ -4727,7 +4726,6 @@ impl UnpackedScalar {
 
 } // verus!
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
@@ -4771,7 +4769,6 @@ impl Field for Scalar {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl PrimeField for Scalar {
     type Repr = [u8; 32];
 
@@ -4844,7 +4841,6 @@ impl PrimeField for Scalar {
 }
 
 #[cfg(feature = "group-bits")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl PrimeFieldBits for Scalar {
     type ReprBits = [u8; 32];
 
@@ -4858,7 +4854,6 @@ impl PrimeFieldBits for Scalar {
 }
 
 #[cfg(feature = "group")]
-#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl FromUniformBytes<64> for Scalar {
     fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
         Scalar::from_bytes_mod_order_wide(bytes)

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -417,6 +417,7 @@ impl Scalar {
         since = "4.0.0",
         note = "This constructor outputs scalars with undefined scalar-scalar arithmetic. See docs."
     )]
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     pub const fn from_bits(bytes: [u8; 32]) -> Scalar {
         let mut s = Scalar { bytes };
         // Ensure invariant #1 holds. That is, make s < 2^255 by masking the high bit.
@@ -975,6 +976,7 @@ impl Neg for Scalar {
 
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl ConditionallySelectable for Scalar {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> (Self) {
         let mut bytes = [0u8;32];
@@ -4725,6 +4727,7 @@ impl UnpackedScalar {
 
 } // verus!
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
@@ -4768,6 +4771,7 @@ impl Field for Scalar {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl PrimeField for Scalar {
     type Repr = [u8; 32];
 
@@ -4840,6 +4844,7 @@ impl PrimeField for Scalar {
 }
 
 #[cfg(feature = "group-bits")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl PrimeFieldBits for Scalar {
     type ReprBits = [u8; 32];
 
@@ -4853,6 +4858,7 @@ impl PrimeFieldBits for Scalar {
 }
 
 #[cfg(feature = "group")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl FromUniformBytes<64> for Scalar {
     fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
         Scalar::from_bytes_mod_order_wide(bytes)

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -493,11 +493,11 @@ impl Index<usize> for Scalar {
     }
 }
 
+#[verifier::external]
 impl Debug for Scalar {
     /* VERIFICATION NOTE: we don't cover debugging */
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `core::fmt::Debug::fmt` (for Scalar)
-    #[verifier::external_body]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Scalar{{\n\tbytes: {:?},\n}}", &self.bytes)
     }
@@ -2078,12 +2078,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 struct ScalarVisitor;
 
 #[cfg(feature = "serde")]
+#[verifier::external]
 impl<'de> Visitor<'de> for ScalarVisitor {
     type Value = Scalar;
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `serde::de::Visitor::expecting` (for ScalarVisitor)
-    #[verifier::external_body]
     fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         {
             formatter.write_str(
@@ -2095,7 +2095,6 @@ impl<'de> Visitor<'de> for ScalarVisitor {
 
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `serde::de::Visitor::visit_seq` (for ScalarVisitor)
-    #[verifier::external_body]
     fn visit_seq<A>(self, mut seq: A) -> Result<Scalar, A::Error> where
         A: serde::de::SeqAccess<'de>,
      {
@@ -2114,10 +2113,10 @@ impl<'de> Visitor<'de> for ScalarVisitor {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+#[verifier::external]
 impl Serialize for Scalar {
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `serde::Serialize::serialize` (for Scalar)
-    #[verifier::external_body]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
         use serde::ser::SerializeTuple;
         let mut tup = serializer.serialize_tuple(32)?;
@@ -2130,10 +2129,10 @@ impl Serialize for Scalar {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+#[verifier::external]
 impl<'de> Deserialize<'de> for Scalar {
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `serde::Deserialize::deserialize` (for Scalar)
-    #[verifier::external_body]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
         /* VERIFICATION NOTE:
         Originally struct ScalarVisitor defined here, but moved up to the top of the file

--- a/curve25519-dalek/src/traits.rs
+++ b/curve25519-dalek/src/traits.rs
@@ -166,6 +166,7 @@ pub trait BasepointTable {
 
     /// Multiply `clamp_integer(bytes)` by this precomputed basepoint table, in constant time. For
     /// a description of clamping, see [`clamp_integer`].
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     fn mul_base_clamped(&self, bytes: [u8; 32]) -> Self::Point {
         // Basepoint multiplication is defined for all values of `bytes` up to and including
         // 2^255 - 1. The limit comes from the fact that scalar.as_radix_16() doesn't work for
@@ -349,6 +350,7 @@ pub trait VartimeMultiscalarMul {
     /// assert_eq!(A1.compress(), (-A2).compress());
     /// # }
     /// ```
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> Self::Point
     where
         I: IntoIterator,
@@ -416,6 +418,7 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
     /// be convertible to iterators (`I: IntoIter`), and the
     /// iterator's items must be `Borrow<Scalar>`, to allow iterators
     /// returning either `Scalar`s or `&Scalar`s.
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     fn vartime_multiscalar_mul<I>(&self, static_scalars: I) -> Self::Point
     where
         I: IntoIterator,
@@ -447,6 +450,7 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
     /// convertible to iterators (`I: IntoIter`), and the iterator's items
     /// must be `Borrow<Scalar>` (or `Borrow<Point>`), to allow
     /// iterators returning either `Scalar`s or `&Scalar`s.
+    #[cfg_attr(verus_keep_ghost, verifier::external)]
     fn vartime_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,

--- a/curve25519-dalek/src/window.rs
+++ b/curve25519-dalek/src/window.rs
@@ -677,6 +677,7 @@ impl<'a> From<&'a EdwardsPoint> for LookupTable<AffineNielsPoint> {
 
 } // verus!
 #[cfg(feature = "zeroize")]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T> Zeroize for LookupTable<T>
 where
     T: Copy + Default + Zeroize,
@@ -775,12 +776,14 @@ impl NafLookupTable5<AffineNielsPoint> {
 
 } // verus!
 // Manual Clone impl since derive(Clone) is not supported inside verus macro for arrays
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T: Copy> Clone for NafLookupTable5<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T: Debug> Debug for NafLookupTable5<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "NafLookupTable5({:?})", self.0)
@@ -1068,6 +1071,7 @@ impl NafLookupTable8<AffineNielsPoint> {
 } // verus!
 // Manual Clone impl since derive(Clone) is not supported inside verus macro for arrays
 #[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T: Copy> Clone for NafLookupTable8<T> {
     fn clone(&self) -> Self {
         *self
@@ -1075,6 +1079,7 @@ impl<T: Copy> Clone for NafLookupTable8<T> {
 }
 
 #[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
+#[cfg_attr(verus_keep_ghost, verifier::external)]
 impl<T: Debug> Debug for NafLookupTable8<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "NafLookupTable8([")?;

--- a/curve25519-dalek/src/window.rs
+++ b/curve25519-dalek/src/window.rs
@@ -389,10 +389,10 @@ impl LookupTable<ProjectiveNielsPoint> {
 }
 
 // Manual Clone implementation to avoid array clone issues in Verus
+#[verifier::external]
 impl<T: Copy> Clone for LookupTable<T> {
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `core::clone::Clone::clone` (for LookupTable)
-    #[verifier::external_body]
     fn clone(&self) -> Self {
         *self
     }
@@ -432,10 +432,10 @@ impl<T: Copy + Default> Default for $name<T> {
     }
 */
 
+#[verifier::external]
 impl<T: Debug> Debug for LookupTable<T> {
     /// ASSUMED SPECIFICATION FOR EXTERNAL FUNCTION:
     /// `core::fmt::Debug::fmt` (for LookupTable)
-    #[verifier::external_body]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}(", stringify!(LookupTable))?;
 


### PR DESCRIPTION
Closes #776.

Move spec-less, out-of-verification-scope functions out of the trust base:

1. **`verus: mark out-of-scope functions with #[verifier::external]`** — marks spec-less functions off every verified proof path (`Debug`/serde/`group`/`ff`/`Clone`/`Zeroize` impls, multiscalar-mul family, `const fn` field helpers, generic trait defaults). Uses `#[cfg_attr(verus_keep_ghost, verifier::external)]` for items outside `verus!{}` blocks. Trait-impl methods marked at the `impl` block; inherent methods individually.
2. **`verus: drop redundant #[verifier::external] on cfg-inactive functions`** — relies on probe-verus P26 (cfg-inactive ⇒ out of scope) instead of explicit annotations.
3. **`verus: move 14 unused no-spec functions out of TCB (external_body -> external)`** — 14 functions carried `#[verifier::external_body]` but have no `requires`/`ensures` and no verus-processed reference: `fmt`×4, `multiscalar_mul`/`optional_multiscalar_mul` on Edwards/Ristretto, `LookupTable::clone`, `RistrettoPoint::random`, serde×4.
4. **`verus: move sum_original x2 out of TCB (external_body -> external)`** — `Edwards/RistrettoPoint::sum_original`: alternative exec `Sum` impls used only by the `#[cfg(test)] mod test_sum` equivalence test.

`EdwardsBasepointTable::clone` stays `external_body` as it's referenced by the *derived* `Clone` of `RistrettoBasepointTable(pub EdwardsBasepointTable)`. 
`iter_count` and `batch_invert_vec` keep `external_body` as they have real specs consumed by verified code.