### PR TITLE
Fix doc/code gaps in Verus annotations

### DIFF
--- a/curve25519-dalek/src/lemmas/edwards_lemmas/straus_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/edwards_lemmas/straus_lemmas.rs
@@ -20,7 +20,7 @@
 //! - `lemma_naf_select_is_signed_scalar_mul_projective`: NafLookupTable5 select -> \[d\] P
 //!
 //! ## Column sum / Horner lemmas:
-//! - `lemma_column_sum_step`: col(j, k+1) = col(j, k) + \[d\_{k,j}\] P\_k
+//! - `lemma_column_sum_step_zero_digit`: col(j, k+1) = col(j, k) when d\_{k,j} = 0
 //! - `lemma_straus_ct_step`: H(j) = \[16\] H(j+1) + col(j, n)
 //! - `lemma_straus_vt_step`: H(i) = \[2\] H(i+1) + col(i, n)
 //!

--- a/curve25519-dalek/src/lemmas/ristretto_lemmas/batch_compress_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/ristretto_lemmas/batch_compress_lemmas.rs
@@ -1066,7 +1066,7 @@ proof fn lemma_u1_u2_sq_factoring(e: nat, f: nat, g: nat, h: nat, eg: nat, fh: n
 /// The proof proceeds in phases:
 ///   Phase A: Establish inv correspondences (zinv = inv(fh), tinv = inv(eg))
 ///   Phase B: Invsqrt factoring via axiom_invsqrt_factors_over_square
-///   Phase C: Show z_inv_std = 1 using axiom_c_iad_sq_identity
+///   Phase C: Show z_inv_std = 1 using lemma_z_inv_std_is_one
 ///   Phase D: Show both algorithms take the same branches and produce s values
 ///            that are equal up to sign, so field_abs equalizes them
 proof fn lemma_batch_std_final_matching(e: nat, f: nat, g: nat, h: nat, eg: nat, fh: nat, inv: nat)

--- a/curve25519-dalek/src/lemmas/scalar_lemmas_/naf_lemmas.rs
+++ b/curve25519-dalek/src/lemmas/scalar_lemmas_/naf_lemmas.rs
@@ -6,7 +6,7 @@
 //! - `lemma_naf_even_step`: Invariant preservation for even window (pos += 1)
 //! - `lemma_naf_odd_step`: Invariant preservation for odd window (pos += w)
 //! - `lemma_naf_digit_bounds`: NAF digit bounds from recentering
-//! - `lemma_naf_terminal_carry`: carry = 0 at loop exit when scalar_val < 2^255
+//! - `lemma_naf_high_bits_zero`: carry = 0 at loop exit when scalar_val < 2^255
 //!
 #![allow(unused_imports)]
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1674,7 +1674,7 @@ impl RistrettoPoint {
     ///
     /// ## VERIFICATION NOTE
     ///
-    /// This function is marked `external_body` for Verus. The Verus-compatible
+    /// This function is marked `external` for Verus. The Verus-compatible
     /// version [`double_and_compress_batch_verus`] provides formal specs with
     /// functional correctness guarantees. The `verus_equivalence_random` test
     /// verifies functional equivalence between the two implementations.
@@ -1759,7 +1759,7 @@ impl RistrettoPoint {
     // `mod test_double_and_compress_batch` at the bottom of this file.
     // ========================================================================
     /// Verus-compatible version that takes a slice instead of IntoIterator.
-    /// Use this for verification; the original double_and_compress_batch API is external_body.
+    /// Use this for verification; the original double_and_compress_batch API is external.
     ///
     /// REFACTORING FOR VERUS:
     /// - Iterator patterns (.map().collect()) replaced with explicit while loops
@@ -3556,7 +3556,7 @@ impl VartimeMultiscalarMul for RistrettoPoint {
   * the Edwards versions. Specs are expressed directly in terms of Edwards
   * operations since we just extract the inner EdwardsPoint and delegate.
   *
-  * Functional equivalence against the original (external_body) implementations is covered by
+  * Functional equivalence against the original (external) implementations is covered by
   * `mod test_multiscalar_mul` at the bottom of this file.
   */
 

--- a/curve25519-dalek/src/specs/edwards_specs.rs
+++ b/curve25519-dalek/src/specs/edwards_specs.rs
@@ -1048,7 +1048,7 @@ pub proof fn lemma_identity_affine_coords(point: EdwardsPoint)
 // Spec functions (in pipeline order):
 //   1. spec_nonspec_map_to_curve       -- top-level: bytes -> [8]P
 //   2. montgomery_to_edwards_affine    -- Montgomery u + sign -> Edwards (x,y)
-//   3. spec_edwards_decompress_from_y      -- Edwards y + sign -> (x,y)
+//   3. edwards_decompress_from_y_and_sign  -- Edwards y + sign -> (x,y)
 //
 // Helper functions (defined elsewhere):
 //   - bytes_seq_as_nat                     -- bytes -> nat (core_specs)


### PR DESCRIPTION
This PR fixes a few mismatches between docstrings and code.

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
